### PR TITLE
Introduce primitives crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
 members = [
 	"key-server",
+	"primitives",
 ]

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "parity-secretstore-primitives"
+version = "1.0.0"
+license = "GPL-3.0"
+authors = ["Parity Technologies <admin@parity.io>"]
+edition = "2018"
+
+[dependencies]
+ethereum-types = "0.8"
+futures = "0.3"
+parity-bytes = "0.1"
+parity-crypto = { version = "0.5", features = ["publickey"] }
+parking_lot = "0.10"
+rustc-hex = "1.0"
+serde = { version = "1.0", features = ["derive"] }
+tiny-keccak = { version = "2.0", features = ["keccak"] }
+tokio-compat = { version = "0.1", features = ["rt-full"] }
+
+[dev-dependencies]
+serde_json = "1.0"

--- a/primitives/src/acl_storage.rs
+++ b/primitives/src/acl_storage.rs
@@ -1,0 +1,57 @@
+// Copyright 2015-2020 Parity Technologies (UK) Ltd.
+// This file is part of Parity Secret Store.
+
+// Parity Secret Store is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity Secret Store is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity Secret Store.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::collections::{HashMap, HashSet};
+use parking_lot::RwLock;
+use ethereum_types::Address;
+use crate::{ServerKeyId, error::Error};
+
+/// ACL storage of Secret Store.
+pub trait AclStorage: Send + Sync {
+	/// Check if owner of `requester_address` can run any operations that are
+	/// touching private data associated with given server key.
+	///
+	/// The private data is either private portion of server key, or document
+	/// key associated with this server key.
+	fn check(&self, requester_address: Address, key_id: &ServerKeyId) -> Result<bool, Error>;
+}
+
+/// In-memory ACL storage implementation.
+///
+/// By default everyone has access to all keys.
+#[derive(Default, Debug)]
+pub struct InMemoryPermissiveAclStorage {
+	forbidden: RwLock<HashMap<Address, HashSet<ServerKeyId>>>,
+}
+
+impl InMemoryPermissiveAclStorage {
+	/// Forbid access to given documents.
+	pub fn forbid(&self, requester: Address, document: ServerKeyId) {
+		self.forbidden.write()
+			.entry(requester)
+			.or_insert_with(Default::default)
+			.insert(document);
+	}
+}
+
+impl AclStorage for InMemoryPermissiveAclStorage {
+	fn check(&self, requester: Address, document: &ServerKeyId) -> Result<bool, Error> {
+		Ok(self.forbidden.read()
+			.get(&requester)
+			.map(|docs| !docs.contains(document))
+			.unwrap_or(true))
+	}
+}

--- a/primitives/src/error.rs
+++ b/primitives/src/error.rs
@@ -1,0 +1,193 @@
+// Copyright 2015-2020 Parity Technologies (UK) Ltd.
+// This file is part of Parity Secret Store.
+
+// Parity Secret Store is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity Secret Store is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity Secret Store.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::fmt;
+use std::net;
+use std::io::Error as IoError;
+use serde::{Serialize, Deserialize};
+use crate::KeyServerId;
+
+/// Secret store error.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum Error {
+	/// Invalid node address has been passed.
+	InvalidNodeAddress,
+	/// Invalid node id has been passed.
+	InvalidNodeId(KeyServerId),
+	/// Session with the given id already exists.
+	DuplicateSessionId,
+	/// No active session with given id.
+	NoActiveSessionWithId,
+	/// Invalid threshold value has been passed.
+	/// Threshold value must be in [0; n - 1], where n is a number of nodes participating in the encryption.
+	NotEnoughNodesForThreshold,
+	/// Current state of encryption/decryption session does not allow to proceed request.
+	/// Reschedule this request for later processing.
+	TooEarlyForRequest,
+	/// Current state of encryption/decryption session does not allow to proceed request.
+	/// This means that either there is some comm-failure or node is misbehaving/cheating.
+	InvalidStateForRequest,
+	/// Request cannot be sent/received from this node.
+	InvalidNodeForRequest,
+	/// Message or some data in the message was recognized as invalid.
+	/// This means that node is misbehaving/cheating.
+	InvalidMessage,
+	/// Message version is not supported.
+	InvalidMessageVersion,
+	/// Message is invalid because of replay-attack protection.
+	ReplayProtection,
+	/// Connection to node, required for this session is not established.
+	NodeDisconnected,
+	/// Server key with this ID is already generated.
+	ServerKeyAlreadyGenerated,
+	/// Server key with this ID is not yet generated.
+	ServerKeyIsNotFound,
+	/// Document key with this ID is already stored.
+	DocumentKeyAlreadyStored,
+	/// Document key with this ID is not yet stored.
+	DocumentKeyIsNotFound,
+	/// Consensus is temporary unreachable. Means that something is currently blocking us from either forming
+	/// consensus group (like disconnecting from too many nodes, which are AGREE to participate in consensus)
+	/// or from rejecting request (disconnecting from AccessDenied-nodes).
+	ConsensusTemporaryUnreachable,
+	/// Consensus is unreachable. It doesn't mean that it will ALWAYS remain unreachable, but right NOW we have
+	/// enough nodes confirmed that they do not want to be a part of consensus. Example: we're connected to 10
+	/// of 100 nodes. Key threshold is 6 (i.e. 7 nodes are required for consensus). 4 nodes are responding with
+	/// reject => consensus is considered unreachable, even though another 90 nodes still can respond with OK.
+	ConsensusUnreachable,
+	/// Acl storage error.
+	AccessDenied,
+	/// Can't start session, because exclusive session is active.
+	ExclusiveSessionActive,
+	/// Can't start exclusive session, because there are other active sessions.
+	HasActiveSessions,
+	/// Insufficient requester data.
+	InsufficientRequesterData(String),
+	/// Cryptographic error.
+	EthKey(String),
+	/// I/O error has occurred.
+	Io(String),
+	/// Deserialization error has occurred.
+	Serde(String),
+	/// Hyper error.
+	Hyper(String),
+	/// Database-related error.
+	Database(String),
+	/// Internal error.
+	Internal(String),
+}
+
+impl Error {
+	/// Is this a fatal error? Non-fatal means that it is possible to replay the same request with a non-zero
+	/// chance to success. I.e. the error is not about request itself (or current environment factors that
+	/// are affecting request processing), but about current SecretStore state.
+	pub fn is_non_fatal(&self) -> bool {
+		match *self {
+			// non-fatal errors:
+
+			// session start errors => restarting session is a solution
+			Error::DuplicateSessionId | Error::NoActiveSessionWithId |
+			// unexpected message errors => restarting session/excluding node is a solution
+			Error::TooEarlyForRequest | Error::InvalidStateForRequest | Error::InvalidNodeForRequest |
+			// invalid message errors => restarting/updating/excluding node is a solution
+			Error::InvalidMessage | Error::InvalidMessageVersion | Error::ReplayProtection |
+			// connectivity problems => waiting for reconnect && restarting session is a solution
+			Error::NodeDisconnected |
+			// temporary (?) consensus problems, related to other non-fatal errors => restarting is probably (!) a solution
+			Error::ConsensusTemporaryUnreachable |
+			// exclusive session errors => waiting && restarting is a solution
+			Error::ExclusiveSessionActive | Error::HasActiveSessions => true,
+
+			// fatal errors:
+
+			// config-related errors
+			Error::InvalidNodeAddress | Error::InvalidNodeId(_) |
+			// wrong session input params errors
+			Error::NotEnoughNodesForThreshold | Error::ServerKeyAlreadyGenerated | Error::ServerKeyIsNotFound |
+				Error::DocumentKeyAlreadyStored | Error::DocumentKeyIsNotFound | Error::InsufficientRequesterData(_) |
+			// access denied/consensus error
+			Error::AccessDenied | Error::ConsensusUnreachable |
+			// indeterminate internal errors, which could be either fatal (db failure, invalid request), or not (network error),
+			// but we still consider these errors as fatal
+			Error::EthKey(_) | Error::Serde(_) | Error::Hyper(_) | Error::Database(_) | Error::Internal(_) | Error::Io(_) => false,
+		}
+	}
+}
+
+impl fmt::Display for Error {
+	fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+		match *self {
+			Error::InvalidNodeAddress => write!(f, "invalid node address has been passed"),
+			Error::InvalidNodeId(ref id) => write!(f, "invalid node id has been passed: {}", id),
+			Error::DuplicateSessionId => write!(f, "session with the same id is already registered"),
+			Error::NoActiveSessionWithId => write!(f, "no active session with given id"),
+			Error::NotEnoughNodesForThreshold => write!(f, "not enough nodes for passed threshold"),
+			Error::TooEarlyForRequest => write!(f, "session is not yet ready to process this request"),
+			Error::InvalidStateForRequest => write!(f, "session is in invalid state for processing this request"),
+			Error::InvalidNodeForRequest => write!(f, "invalid node for this request"),
+			Error::InvalidMessage => write!(f, "invalid message is received"),
+			Error::InvalidMessageVersion => write!(f, "unsupported message is received"),
+			Error::ReplayProtection => write!(f, "replay message is received"),
+			Error::NodeDisconnected => write!(f, "node required for this operation is currently disconnected"),
+			Error::ServerKeyAlreadyGenerated => write!(f, "Server key with this ID is already generated"),
+			Error::ServerKeyIsNotFound => write!(f, "Server key with this ID is not found"),
+			Error::DocumentKeyAlreadyStored => write!(f, "Document key with this ID is already stored"),
+			Error::DocumentKeyIsNotFound => write!(f, "Document key with this ID is not found"),
+			Error::ConsensusUnreachable => write!(f, "Consensus unreachable"),
+			Error::ConsensusTemporaryUnreachable => write!(f, "Consensus temporary unreachable"),
+			Error::AccessDenied => write!(f, "Access denied"),
+			Error::ExclusiveSessionActive => write!(f, "Exclusive session active"),
+			Error::HasActiveSessions => write!(f, "Unable to start exclusive session"),
+			Error::InsufficientRequesterData(ref e) => write!(f, "Insufficient requester data: {}", e),
+			Error::EthKey(ref e) => write!(f, "cryptographic error {}", e),
+			Error::Hyper(ref msg) => write!(f, "Hyper error: {}", msg),
+			Error::Serde(ref msg) => write!(f, "Serialization error: {}", msg),
+			Error::Database(ref msg) => write!(f, "Database error: {}", msg),
+			Error::Internal(ref msg) => write!(f, "Internal error: {}", msg),
+			Error::Io(ref msg) => write!(f, "IO error: {}", msg),
+		}
+	}
+}
+
+impl From<parity_crypto::publickey::Error> for Error {
+	fn from(err: parity_crypto::publickey::Error) -> Self {
+		Error::EthKey(err.into())
+	}
+}
+
+impl From<parity_crypto::Error> for Error {
+	fn from(err: parity_crypto::Error) -> Self {
+		Error::EthKey(err.to_string())
+	}
+}
+
+impl From<IoError> for Error {
+	fn from(err: IoError) -> Self {
+		Error::Io(err.to_string())
+	}
+}
+
+impl Into<String> for Error {
+	fn into(self) -> String {
+		format!("{}", self)
+	}
+}
+
+impl From<net::AddrParseError> for Error {
+	fn from(err: net::AddrParseError) -> Error {
+		Error::Internal(err.to_string())
+	}
+}

--- a/primitives/src/executor.rs
+++ b/primitives/src/executor.rs
@@ -1,0 +1,41 @@
+// Copyright 2015-2020 Parity Technologies (UK) Ltd.
+// This file is part of Parity Secret Store.
+
+// Parity Secret Store is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity Secret Store is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity Secret Store.  If not, see <http://www.gnu.org/licenses/>.
+
+use futures::future::BoxFuture;
+use crate::error::Error;
+
+/// Futures executor.
+pub trait Executor: Send + Sync + 'static {
+	/// Spawn future and run to completion.
+	fn spawn(&self, future: BoxFuture<'static, ()>);
+}
+
+/// Alias for tokio-compat runtime.
+pub type TokioRuntime = tokio_compat::runtime::Runtime;
+
+/// Alias for tokio-compat runtime handle.
+pub type TokioHandle = tokio_compat::runtime::TaskExecutor;
+
+/// Create new tokio runtime.
+pub fn tokio_runtime() -> Result<TokioRuntime, Error> {
+	TokioRuntime::new().map_err(|err| Error::Internal(format!("{}", err)))
+}
+
+impl Executor for TokioHandle {
+	fn spawn(&self, future: BoxFuture<'static, ()>) {
+		TokioHandle::spawn_std(self, future);
+	}
+}

--- a/primitives/src/key_server.rs
+++ b/primitives/src/key_server.rs
@@ -1,0 +1,408 @@
+// Copyright 2015-2020 Parity Technologies (UK) Ltd.
+// This file is part of Parity Secret Store.
+
+// Parity Secret Store is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity Secret Store is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity Secret Store.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::future::Future;
+use ethereum_types::{Address, H160, H256};
+use parity_crypto::publickey::{Public, Signature};
+use crate::{
+	KeyServerId, KeyServerPublic, ServerKeyId,
+	error::Error,
+	requester::Requester,
+};
+
+/// Session origin. Origin can be used by some services if they're working with
+/// several endpoints (like ethereum service could listen to several contracts).
+pub type Origin = H160;
+
+/// Session result.
+pub struct SessionResult<P, R> {
+	/// Session origin.
+	pub origin: Option<Origin>,
+	/// Session parameters.
+	pub params: P,
+	/// Actual result.
+	pub result: Result<R, Error>,
+}
+
+/// Essential server key generation params.
+#[derive(Clone)]
+pub struct ServerKeyGenerationParams {
+	/// Key id.
+	pub key_id: ServerKeyId,
+}
+
+/// Server key generation artifacts.
+#[derive(Clone)]
+pub struct ServerKeyGenerationArtifacts {
+	/// Public portion of generated server key.
+	pub key: Public,
+}
+
+/// Result of server key generation session.
+pub type ServerKeyGenerationResult = SessionResult<ServerKeyGenerationParams, ServerKeyGenerationArtifacts>;
+
+/// Essential server key retrieval params.
+#[derive(Clone)]
+pub struct ServerKeyRetrievalParams {
+	/// Key id.
+	pub key_id: ServerKeyId,
+}
+
+/// Server key retrieval artifacts.
+#[derive(Clone)]
+pub struct ServerKeyRetrievalArtifacts {
+	/// Server key author.
+	pub author: Address,
+	/// Public portion of retrieved server key.
+	pub key: Public,
+	/// Threshold that has been used to generate server key.
+	pub threshold: usize,
+}
+
+/// Result of server key retrieval session.
+pub type ServerKeyRetrievalResult = SessionResult<ServerKeyRetrievalParams, ServerKeyRetrievalArtifacts>;
+
+/// Server key (SK) generator.
+pub trait ServerKeyGenerator {
+	/// SK generation future.
+	type GenerateKeyFuture: Future<Output = ServerKeyGenerationResult> + Send;
+	/// SK restore future.
+	type RestoreKeyFuture: Future<Output = ServerKeyRetrievalResult> + Send;
+
+	/// Generate new SK.
+	/// `key_id` is the caller-provided identifier of generated SK.
+	/// `author` is the author of key entry.
+	/// `threshold + 1` is the minimal number of nodes, required to restore private key.
+	/// Result is a public portion of SK.
+	fn generate_key(
+		&self,
+		origin: Option<Origin>,
+		key_id: ServerKeyId,
+		author: Requester,
+		threshold: usize,
+	) -> Self::GenerateKeyFuture;
+	/// Retrieve public portion of previously generated SK.
+	/// `key_id` is identifier of previously generated SK.
+	/// `author` is the same author, that has created the server key.
+	/// If `author` is `None`, then author-check is omitted.
+	fn restore_key_public(
+		&self,
+		origin: Option<Origin>,
+		key_id: ServerKeyId,
+		author: Option<Requester>,
+	) -> Self::RestoreKeyFuture;
+}
+
+/// Essential document key store params.
+#[derive(Clone)]
+pub struct DocumentKeyStoreParams {
+	/// Key id.
+	pub key_id: ServerKeyId,
+}
+
+/// Document key store artifacts.
+#[derive(Clone)]
+pub struct DocumentKeyStoreArtifacts;
+
+/// Result of document key store session.
+pub type DocumentKeyStoreResult = SessionResult<DocumentKeyStoreParams, DocumentKeyStoreArtifacts>;
+
+/// Essential document key generation params.
+#[derive(Clone)]
+pub struct DocumentKeyGenerationParams {
+	/// Key id.
+	pub key_id: ServerKeyId,
+}
+
+/// Dcument key generation artifacts.
+#[derive(Clone)]
+pub struct DocumentKeyGenerationArtifacts {
+	/// Generated document key. UNENCRYPTED.
+	pub document_key: Public,
+}
+
+/// Result of document key generation session.
+pub type DocumentKeyGenerationResult = SessionResult<DocumentKeyGenerationParams, DocumentKeyGenerationArtifacts>;
+
+/// Essential document key retrieval params.
+#[derive(Clone)]
+pub struct DocumentKeyRetrievalParams {
+	/// Key id.
+	pub key_id: ServerKeyId,
+	/// Key requester.
+	pub requester: Requester,
+}
+
+/// Document key retrieval artifacts.
+#[derive(Clone)]
+pub struct DocumentKeyRetrievalArtifacts {
+	/// Restored document key. UNENCRYPTED.
+	pub document_key: Public,
+}
+
+/// Result of document key retrieval session.
+pub type DocumentKeyRetrievalResult = SessionResult<DocumentKeyRetrievalParams, DocumentKeyRetrievalArtifacts>;
+
+/// Essential document key common retrieval params.
+#[derive(Clone)]
+pub struct DocumentKeyCommonRetrievalParams {
+	/// Key id.
+	pub key_id: ServerKeyId,
+	/// Key requester.
+	pub requester: Requester,
+}
+
+/// Document key common retrieval artifacts.
+///
+/// This data isn't enough to recover document key and could only be used for
+/// establishing consensus over `common_point` and `threshold`.
+#[derive(Clone)]
+pub struct DocumentKeyCommonRetrievalArtifacts {
+	/// The common point of portion of encrypted document keys. Common point is
+	/// shared among all key servers that aware of the given document key.
+	pub common_point: Public,
+	/// Threshold that has been used to generate associated server key.
+	pub threshold: usize,
+}
+
+/// Result of document key common retrieval session.
+pub type DocumentKeyCommonRetrievalResult = SessionResult<
+	DocumentKeyCommonRetrievalParams,
+	DocumentKeyCommonRetrievalArtifacts,
+>;
+
+/// Essential document key shadow retrieval params.
+#[derive(Clone)]
+pub struct DocumentKeyShadowRetrievalParams {
+	/// Key id.
+	pub key_id: ServerKeyId,
+	/// Key requester.
+	pub requester: Requester,
+}
+
+/// Document key shadow retrieval artifacts.
+///
+/// The data is enough to decrypt document key by the owner of corresponding
+/// requester key.
+#[derive(Clone)]
+pub struct DocumentKeyShadowRetrievalArtifacts {
+	/// The common point of portion of encrypted document keys. Common point is
+	/// shared among all key servers that aware of the given document key.
+	pub common_point: Public,
+	/// Threshold that has been used to generate associated server key.
+	pub threshold: usize,
+	/// Partially decrypted document key.
+	pub encrypted_document_key: Public,
+	/// Key servers that has participated in decryption session along with their
+	/// shadow coefficients. Shadow coefficients are encrypted with requester public
+	/// key. After decryption, they can be used to finally decrypt document key.
+	pub participants_coefficients: BTreeMap<KeyServerId, Vec<u8>>,
+}
+
+/// Result of document key shadow retrieval session.
+pub type DocumentKeyShadowRetrievalResult = SessionResult<
+	DocumentKeyShadowRetrievalParams,
+	DocumentKeyShadowRetrievalArtifacts,
+>;
+
+/// Document key (DK) server.
+pub trait DocumentKeyServer: ServerKeyGenerator {
+	/// DK store future.
+	type StoreDocumentKeyFuture: Future<Output = DocumentKeyStoreResult> + Send;
+	/// DK generation future.
+	type GenerateDocumentKeyFuture: Future<Output = DocumentKeyGenerationResult> + Send;
+	/// DK restore future.
+	type RestoreDocumentKeyFuture: Future<Output = DocumentKeyRetrievalResult> + Send;
+	/// DK common part restore future.
+	type RestoreDocumentKeyCommonFuture: Future<Output = DocumentKeyCommonRetrievalResult> + Send;
+	/// DK shadow restore future.
+	type RestoreDocumentKeyShadowFuture: Future<Output = DocumentKeyShadowRetrievalResult> + Send;
+
+	/// Store externally generated DK.
+	/// `key_id` is identifier of previously generated SK.
+	/// `author` is the same author, that has created the server key.
+	/// `common_point` is a result of `k * T` expression, where `T` is generation point
+	/// and `k` is random scalar in EC field.
+	/// `encrypted_document_key` is a result of `M + k * y` expression, where `M` is unencrypted document key (point on EC),
+	///   `k` is the same scalar used in `common_point` calculation and `y` is previously generated public part of SK.
+	fn store_document_key(
+		&self,
+		origin: Option<Origin>,
+		key_id: ServerKeyId,
+		author: Requester,
+		common_point: Public,
+		encrypted_document_key: Public,
+	) -> Self::StoreDocumentKeyFuture;
+	/// Generate and store both SK and DK. This is a shortcut for consequent calls of `generate_key` and `store_document_key`.
+	/// The only difference is that DK is generated by DocumentKeyServer (which might be considered unsafe).
+	/// `key_id` is the caller-provided identifier of generated SK.
+	/// `author` is the author of server && document key entry.
+	/// `threshold + 1` is the minimal number of nodes, required to restore private key.
+	/// Result is a DK, encrypted with caller public key.
+	fn generate_document_key(
+		&self,
+		origin: Option<Origin>,
+		key_id: ServerKeyId,
+		author: Requester,
+		threshold: usize,
+	) -> Self::GenerateDocumentKeyFuture;
+	/// Restore previously stored DK.
+	/// DK is decrypted on the key server (which might be considered unsafe), and then encrypted with caller public key.
+	/// `key_id` is identifier of previously generated SK.
+	/// `requester` is the one who requests access to document key. Caller must be on ACL for this function to succeed.
+	/// Result is a DK, encrypted with caller public key.
+	fn restore_document_key(
+		&self,
+		origin: Option<Origin>,
+		key_id: ServerKeyId,
+		requester: Requester,
+	) -> Self::RestoreDocumentKeyFuture;
+	/// Restore portion of DK that is the same among all key servers.
+	fn restore_document_key_common(
+		&self,
+		origin: Option<Origin>,
+		key_id: ServerKeyId,
+		requester: Requester,
+	) -> Self::RestoreDocumentKeyCommonFuture;
+	/// Restore previously stored DK.
+	/// To decrypt DK on client:
+	/// 1) use requestor secret key to decrypt secret coefficients from result.decrypt_shadows
+	/// 2) calculate decrypt_shadows_sum = sum of all secrets from (1)
+	/// 3) calculate decrypt_shadow_point: decrypt_shadows_sum * result.common_point
+	/// 4) calculate decrypted_secret: result.decrypted_secret + decrypt_shadow_point
+	/// Result is a DK shadow.
+	fn restore_document_key_shadow(
+		&self,
+		origin: Option<Origin>,
+		key_id: ServerKeyId,
+		requester: Requester,
+	) -> Self::RestoreDocumentKeyShadowFuture;
+}
+
+/// Essential Schnorr signing params.
+#[derive(Clone)]
+pub struct SchnorrSigningParams {
+	/// Key id.
+	pub key_id: ServerKeyId,
+	/// Key requester.
+	pub requester: Requester,
+}
+
+/// Schnorr signing artifacts.
+#[derive(Clone)]
+pub struct SchnorrSigningArtifacts {
+	/// C portion of Schnorr signature. UNENCRYPTED.
+	pub signature_c: H256,
+	/// S portion of Schnorr signature. UNENCRYPTED.
+	pub signature_s: H256,
+}
+
+/// Result of Schnorr signing session.
+pub type SchnorrSigningResult = SessionResult<SchnorrSigningParams, SchnorrSigningArtifacts>;
+
+/// Essential ECDSA signing params.
+#[derive(Clone)]
+pub struct EcdsaSigningParams {
+	/// Key id.
+	pub key_id: ServerKeyId,
+	/// Key requester.
+	pub requester: Requester,
+}
+
+/// ECDSA signing artifacts.
+#[derive(Clone)]
+pub struct EcdsaSigningArtifacts {
+	/// ECDSA signature. UNENCRYPTED.
+	pub signature: Signature,
+}
+
+/// Result of ECDSA signing session.
+pub type EcdsaSigningResult = SessionResult<EcdsaSigningParams, EcdsaSigningArtifacts>;
+
+/// Message signer.
+pub trait MessageSigner: ServerKeyGenerator {
+	/// Schnorr signing future.
+	type SignMessageSchnorrFuture: Future<Output = SchnorrSigningResult> + Send;
+	/// ECDSA signing future.
+	type SignMessageEcdsaFuture: Future<Output = EcdsaSigningResult> + Send;
+
+	/// Generate Schnorr signature for message with previously generated SK.
+	/// `key_id` is the caller-provided identifier of generated SK.
+	/// `requester` is the one who requests access to server key private.
+	/// `message` is the message to be signed.
+	/// Result is a signed message, encrypted with caller public key.
+	fn sign_message_schnorr(
+		&self,
+		origin: Option<Origin>,
+		key_id: ServerKeyId,
+		requester: Requester,
+		message: H256,
+	) -> Self::SignMessageSchnorrFuture;
+	/// Generate ECDSA signature for message with previously generated SK.
+	/// WARNING: only possible when SK was generated using t <= 2 * N.
+	/// `key_id` is the caller-provided identifier of generated SK.
+	/// `signature` is `key_id`, signed with caller public key.
+	/// `message` is the hash of message to be signed.
+	/// Result is a signed message, encrypted with caller public key.
+	fn sign_message_ecdsa(
+		&self,
+		origin: Option<Origin>,
+		key_id: ServerKeyId,
+		requester: Requester,
+		message: H256,
+	) -> Self::SignMessageEcdsaFuture;
+}
+
+/// Administrative sessions server.
+pub trait AdminSessionsServer {
+	/// Change servers set future.
+	type ChangeServersSetFuture: Future<Output = SessionResult<(), ()>> + Send;
+
+	/// Change servers set so that nodes in new_servers_set became owners of shares for all keys.
+	/// And old nodes (i.e. cluster nodes except new_servers_set) have clear databases.
+	/// WARNING: newly generated keys will be distributed among all cluster nodes. So this session
+	/// must be followed with cluster nodes change (either via contract, or config files).
+	fn change_servers_set(
+		&self,
+		origin: Option<Origin>,
+		old_set_signature: Signature,
+		new_set_signature: Signature,
+		new_servers_set: BTreeSet<KeyServerPublic>,
+	) -> Self::ChangeServersSetFuture;
+}
+
+/// Key server.
+pub trait KeyServer: AdminSessionsServer + DocumentKeyServer + MessageSigner + Send + Sync + 'static {
+}
+
+impl<P, R> SessionResult<P, R> {
+	/// Result::map().
+	pub fn map<U>(self, f: impl Fn(R) -> U) -> Result<U, Error> {
+		self.result.map(f)
+	}
+
+	/// Result::map_err().
+	pub fn map_err<E>(self, f: impl Fn(Error) -> E) -> Result<R, E> {
+		self.result.map_err(f)
+	}
+}
+
+impl<P, R> Into<Result<R, Error>> for SessionResult<P, R> {
+	fn into(self: SessionResult<P, R>) -> Result<R, Error> {
+		self.result
+	}
+}

--- a/primitives/src/key_server_key_pair.rs
+++ b/primitives/src/key_server_key_pair.rs
@@ -1,0 +1,65 @@
+// Copyright 2015-2020 Parity Technologies (UK) Ltd.
+// This file is part of Parity Secret Store.
+
+// Parity Secret Store is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity Secret Store is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity Secret Store.  If not, see <http://www.gnu.org/licenses/>.
+
+use ethereum_types::H256;
+use parity_crypto::publickey::{Address, KeyPair, Public, Signature, public_to_address, sign};
+use crate::error::Error;
+
+/// Key Server key pair.
+///
+/// Every key server owns a key pair that it is used to encrypt its private data and
+/// sign its messages.
+pub trait KeyServerKeyPair: Send + Sync {
+	/// Get public portion of key.
+	fn public(&self) -> &Public;
+	/// Get address of key owner.
+	fn address(&self) -> Address;
+	/// Sign data with the key.
+	fn sign(&self, data: &H256) -> Result<Signature, Error>;
+}
+
+/// In-memory implementation of server key pair.
+pub struct InMemoryKeyServerKeyPair {
+	key_pair: KeyPair,
+}
+
+impl InMemoryKeyServerKeyPair {
+	/// Create new key server key pair using given key pair.
+	pub fn new(key_pair: KeyPair) -> Self {
+		InMemoryKeyServerKeyPair {
+			key_pair: key_pair,
+		}
+	}
+
+	/// Get key pair reference.
+	pub fn key_pair(&self) -> &KeyPair {
+		&self.key_pair
+	}
+}
+
+impl KeyServerKeyPair for InMemoryKeyServerKeyPair {
+	fn public(&self) -> &Public {
+		self.key_pair.public()
+	}
+
+	fn address(&self) -> Address {
+		public_to_address(self.key_pair.public())
+	}
+
+	fn sign(&self, data: &H256) -> Result<Signature, Error> {
+		sign(self.key_pair.secret(), data).map_err(Into::into)
+	}
+}

--- a/primitives/src/key_server_set.rs
+++ b/primitives/src/key_server_set.rs
@@ -1,0 +1,108 @@
+// Copyright 2015-2020 Parity Technologies (UK) Ltd.
+// This file is part of Parity Secret Store.
+
+// Parity Secret Store is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity Secret Store is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity Secret Store.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::{
+	collections::BTreeMap,
+	fmt::Debug,
+	net::SocketAddr,
+};
+use ethereum_types::H256;
+use crate::KeyServerId;
+
+/// Every migration process has its own unique id.
+pub type MigrationId = H256;
+
+/// Key Server Set state.
+#[derive(Default, Debug, Clone, PartialEq)]
+pub struct KeyServerSetSnapshot<Address> {
+	/// Current set of key servers.
+	pub current_set: BTreeMap<KeyServerId, Address>,
+	/// New set of key servers. If it differs from the current set, then
+	/// the migration should be started.
+	pub new_set: BTreeMap<KeyServerId, Address>,
+	/// Current migration data. None if migration isn't started.
+	pub migration: Option<KeyServerSetMigration<Address>>,
+}
+
+/// Key Server set migration.
+#[derive(Default, Debug, Clone, PartialEq)]
+pub struct KeyServerSetMigration<Address> {
+	/// Migration id.
+	pub id: MigrationId,
+	/// Migration set of key servers. It is the new_set at the moment when
+	/// migration has been started.
+	pub set: BTreeMap<KeyServerId, Address>,
+	/// Master node of the migration process.
+	pub master: KeyServerId,
+	/// Is migration confirmed by this node?
+	pub is_confirmed: bool,
+}
+
+/// Key Server Set.
+pub trait KeyServerSet: Send + Sync {
+	/// Type of address we need to know to connect remote key servers.
+	type NetworkAddress: Send + Sync;
+
+	/// Is this node currently isolated from the set?
+	fn is_isolated(&self) -> bool;
+	/// Get server set state.
+	fn snapshot(&self) -> KeyServerSetSnapshot<Self::NetworkAddress>;
+	/// Start migration.
+	fn start_migration(&self, migration_id: MigrationId);
+	/// Confirm migration.
+	fn confirm_migration(&self, migration_id: MigrationId);
+}
+
+/// In-memory key server set implementation.
+#[derive(Default)]
+pub struct InMemoryKeyServerSet {
+	is_isolated: bool,
+	nodes: BTreeMap<KeyServerId, SocketAddr>,
+}
+
+impl InMemoryKeyServerSet {
+	/// Create new in-memory key server set.
+	pub fn new(is_isolated: bool, nodes: BTreeMap<KeyServerId, SocketAddr>) -> Self {
+		InMemoryKeyServerSet {
+			is_isolated: is_isolated,
+			nodes: nodes,
+		}
+	}
+}
+
+impl KeyServerSet for InMemoryKeyServerSet {
+	type NetworkAddress = SocketAddr;
+
+	fn is_isolated(&self) -> bool {
+		self.is_isolated
+	}
+
+	fn snapshot(&self) -> KeyServerSetSnapshot<Self::NetworkAddress> {
+		KeyServerSetSnapshot {
+			current_set: self.nodes.clone(),
+			new_set: self.nodes.clone(),
+			migration: None,
+		}
+	}
+
+	fn start_migration(&self, _migration_id: MigrationId) {
+		// nothing to do here
+	}
+
+	fn confirm_migration(&self, _migration_id: MigrationId) {
+		// nothing to do here
+	}
+}

--- a/primitives/src/key_storage.rs
+++ b/primitives/src/key_storage.rs
@@ -1,0 +1,153 @@
+// Copyright 2015-2020 Parity Technologies (UK) Ltd.
+// This file is part of Parity Secret Store.
+
+// Parity Secret Store is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity Secret Store is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity Secret Store.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::collections::{BTreeMap, HashMap};
+use parking_lot::RwLock;
+use tiny_keccak::{Hasher, Keccak};
+use ethereum_types::H256;
+use parity_crypto::publickey::{Address, Public, Secret};
+use crate::{error::Error, KeyServerId, ServerKeyId};
+
+/// Encrypted key share, stored by key storage on the single key server.
+#[derive(Debug, Default, Clone, PartialEq)]
+pub struct KeyShare {
+	/// Author of the entry.
+	pub author: Address,
+	/// Decryption threshold (at least threshold + 1 nodes are required to decrypt data).
+	pub threshold: usize,
+	/// Server public key.
+	pub public: Public,
+	/// Doument key: common (shared) encryption point.
+	pub common_point: Option<Public>,
+	/// Doument key: encrypted point.
+	pub encrypted_point: Option<Public>,
+	/// Key share versions.
+	pub versions: Vec<KeyShareVersion>,
+}
+
+/// Versioned portion of key share.
+#[derive(Debug, Clone, PartialEq)]
+pub struct KeyShareVersion {
+	/// Version hash (Keccak(time + id_numbers)).
+	pub hash: H256,
+	/// Nodes ids numbers.
+	pub id_numbers: BTreeMap<KeyServerId, Secret>,
+	/// Secret share of secret portion of server key, valid within this version.
+	pub secret_share: Secret,
+}
+
+
+/// Secret Store key storage.
+pub trait KeyStorage: Send + Sync + 'static {
+	/// Insert new key share.
+	fn insert(&self, key_id: ServerKeyId, key: KeyShare) -> Result<(), Error>;
+	/// Update existing key share.
+	fn update(&self, key_id: ServerKeyId, key: KeyShare) -> Result<(), Error>;
+	/// Get existing key share.
+	fn get(&self, key_id: &ServerKeyId) -> Result<Option<KeyShare>, Error>;
+	/// Remove key share.
+	fn remove(&self, key_id: &ServerKeyId) -> Result<(), Error>;
+	/// Clears the database.
+	fn clear(&self) -> Result<(), Error>;
+	/// Check if storage contains encryption key
+	fn contains(&self, key_id: &ServerKeyId) -> bool;
+	/// Iterate through storage.
+	fn iter<'a>(&'a self) -> Box<dyn Iterator<Item=(ServerKeyId, KeyShare)> + 'a>;
+}
+
+/// In-memory key storage implementation.
+#[derive(Debug, Default)]
+pub struct InMemoryKeyStorage {
+	keys: RwLock<HashMap<ServerKeyId, KeyShare>>,
+}
+
+impl KeyStorage for InMemoryKeyStorage {
+	fn insert(&self, key_id: ServerKeyId, key: KeyShare) -> Result<(), Error> {
+		self.keys.write().insert(key_id, key);
+		Ok(())
+	}
+
+	fn update(&self, key_id: ServerKeyId, key: KeyShare) -> Result<(), Error> {
+		self.keys.write().insert(key_id, key);
+		Ok(())
+	}
+
+	fn get(&self, key_id: &ServerKeyId) -> Result<Option<KeyShare>, Error> {
+		Ok(self.keys.read().get(key_id).cloned())
+	}
+
+	fn remove(&self, key_id: &ServerKeyId) -> Result<(), Error> {
+		self.keys.write().remove(key_id);
+		Ok(())
+	}
+
+	fn clear(&self) -> Result<(), Error> {
+		self.keys.write().clear();
+		Ok(())
+	}
+
+	fn contains(&self, key_id: &ServerKeyId) -> bool {
+		self.keys.read().contains_key(key_id)
+	}
+
+	fn iter<'a>(&'a self) -> Box<dyn Iterator<Item=(ServerKeyId, KeyShare)> + 'a> {
+		Box::new(self.keys.read().clone().into_iter())
+	}
+}
+
+impl KeyShare {
+	/// Get last version reference.
+	pub fn last_version(&self) -> Result<&KeyShareVersion, Error> {
+		self.versions
+			.last()
+			.ok_or_else(|| Error::Database("key version is not found".into()))
+	}
+
+	/// Get given version reference.
+	pub fn version(&self, version: &H256) -> Result<&KeyShareVersion, Error> {
+		self.versions
+			.iter()
+			.rev()
+			.find(|v| &v.hash == version)
+			.ok_or_else(|| Error::Database("key version is not found".into()))
+	}
+}
+
+impl KeyShareVersion {
+	/// Create new version.
+	pub fn new(id_numbers: BTreeMap<KeyServerId, Secret>, secret_share: Secret) -> Self {
+		KeyShareVersion {
+			hash: Self::data_hash(id_numbers.iter().map(|(k, v)| (k.as_bytes(), v.as_bytes()))),
+			id_numbers: id_numbers,
+			secret_share: secret_share,
+		}
+	}
+
+	/// Calculate hash of given version data.
+	pub fn data_hash<'a, I>(id_numbers: I) -> H256 where I: Iterator<Item=(&'a [u8], &'a [u8])> {
+		let mut nodes_keccak = Keccak::v256();
+
+		for (node, node_number) in id_numbers {
+			nodes_keccak.update(node);
+			nodes_keccak.update(node_number);
+		}
+
+		let mut nodes_keccak_value = [0u8; 32];
+		nodes_keccak.finalize(&mut nodes_keccak_value);
+
+		nodes_keccak_value.into()
+	}
+}

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -1,0 +1,53 @@
+// Copyright 2015-2020 Parity Technologies (UK) Ltd.
+// This file is part of Parity Secret Store.
+
+// Parity Secret Store is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity Secret Store is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity Secret Store.  If not, see <http://www.gnu.org/licenses/>.
+
+// to avoid extra dependencies if you're using primitives
+pub use ethereum_types::H256;
+pub use parity_bytes::Bytes;
+pub use parity_crypto::publickey::{Address, Public, Signature};
+
+/// Every key server owns a key. This type is used where we need to encrypt
+/// message to this server key.
+pub type KeyServerPublic = Public;
+/// Key server address is derived from its own public key. This type is used
+/// when we need to identify server key.
+pub type KeyServerId = Address;
+
+/// Every server key has its own id. This could be a hash of some document
+/// that should be encrypted by this key.
+pub type ServerKeyId = H256;
+
+pub mod acl_storage;
+pub mod error;
+pub mod executor;
+pub mod key_server;
+pub mod key_server_key_pair;
+pub mod key_server_set;
+pub mod key_storage;
+pub mod requester;
+pub mod serialization;
+pub mod service;
+
+/// Encrypt given data using Elliptic Curve Integrated Encryption Scheme.
+pub fn ecies_encrypt(
+	public: &Public,
+	data: &[u8],
+) -> Result<Bytes, crate::error::Error> {
+	parity_crypto::publickey::ecies::encrypt(public, &parity_crypto::DEFAULT_MAC, data)
+		.map_err(|error| crate::error::Error::Internal(
+			format!("Error encrypting data (ECIES): {}", error),
+		))
+}

--- a/primitives/src/requester.rs
+++ b/primitives/src/requester.rs
@@ -1,0 +1,73 @@
+// Copyright 2015-2020 Parity Technologies (UK) Ltd.
+// This file is part of Parity Secret Store.
+
+// Parity Secret Store is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity Secret Store is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity Secret Store.  If not, see <http://www.gnu.org/licenses/>.
+
+use parity_crypto::publickey::{Address, Public, Signature, public_to_address, recover};
+use crate::{error::Error, ServerKeyId};
+
+/// Requester identification data.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum Requester {
+	/// Requested with server key id signature.
+	Signature(Signature),
+	/// Requested with public key.
+	Public(Public),
+	/// Requested with verified address.
+	Address(Address),
+}
+
+impl Requester {
+	/// Return requester public key.
+	pub fn public(&self, server_key_id: &ServerKeyId) -> Result<Public, Error> {
+		match *self {
+			Requester::Signature(ref signature) => recover(signature, server_key_id)
+				.map_err(|e| Error::Internal(format!("bad signature: {}", e))),
+			Requester::Public(ref public) => Ok(public.clone()),
+			Requester::Address(_) => Err(Error::InsufficientRequesterData("cannot recover public from address".into())),
+		}
+	}
+
+	/// Return requester address.
+	pub fn address(&self, server_key_id: &ServerKeyId) -> Result<Address, Error> {
+		match *self {
+			Requester::Address(address) => Ok(address),
+			_ => self.public(server_key_id).map(|p| public_to_address(&p)),
+		}
+	}
+}
+
+impl From<Signature> for Requester {
+	fn from(signature: Signature) -> Requester {
+		Requester::Signature(signature)
+	}
+}
+
+impl From<Public> for Requester {
+	fn from(public: Public) -> Requester {
+		Requester::Public(public)
+	}
+}
+
+impl From<Address> for Requester {
+	fn from(address: Address) -> Requester {
+		Requester::Address(address)
+	}
+}
+
+impl std::fmt::Display for Requester {
+	fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
+		write!(f, "{:?}", self)
+	}
+}

--- a/primitives/src/serialization.rs
+++ b/primitives/src/serialization.rs
@@ -1,0 +1,245 @@
+// Copyright 2015-2020 Parity Technologies (UK) Ltd.
+// This file is part of Parity Secret Store.
+
+// Parity Secret Store is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity Secret Store is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity Secret Store.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::fmt;
+use std::ops::Deref;
+use rustc_hex::{self, FromHex};
+use serde::{Serialize, Deserialize, Serializer, Deserializer};
+use serde::de::{Visitor, Error as SerdeError};
+use parity_crypto::publickey::{Public, Secret, Signature};
+use ethereum_types::{H160, H256};
+use parity_bytes::Bytes;
+use crate::requester::Requester;
+
+trait ToHex {
+	fn to_hex(&self) -> String;
+}
+
+impl ToHex for Bytes {
+	fn to_hex(&self) -> String {
+		format!("0x{}", rustc_hex::ToHex::to_hex(&self[..]))
+	}
+}
+
+impl ToHex for Signature {
+	fn to_hex(&self) -> String {
+		format!("0x{}", self)
+	}
+}
+
+impl ToHex for Secret {
+	fn to_hex(&self) -> String {
+		format!("0x{}", self.to_hex())
+	}
+}
+
+macro_rules! impl_to_hex {
+	($name: ident) => (
+		impl ToHex for $name {
+			fn to_hex(&self) -> String {
+				format!("{:#x}", self)
+			}
+		}
+	);
+}
+
+macro_rules! impl_bytes_deserialize {
+	($name: ident, $value: expr, true) => {
+		$value[2..].from_hex().map($name).map_err(SerdeError::custom)
+	};
+	($name: ident, $value: expr, false) => {
+		$value[2..].parse().map($name).map_err(SerdeError::custom)
+	}
+}
+
+macro_rules! impl_bytes {
+	($name: ident, $other: ident, $from_hex: ident, ($($trait: ident),*)) => {
+		#[derive(Clone, Debug, PartialEq, Eq, $($trait,)*)]
+		pub struct $name(pub $other);
+
+		impl<T> From<T> for $name where $other: From<T> {
+			fn from(s: T) -> $name {
+				$name(s.into())
+			}
+		}
+
+		impl Into<$other> for $name {
+			fn into(self) -> $other {
+				self.0
+			}
+		}
+
+		impl Deref for $name {
+			type Target = $other;
+
+			fn deref(&self) -> &$other {
+				&self.0
+			}
+		}
+
+		impl Serialize for $name {
+			fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: Serializer {
+				serializer.serialize_str(<$other as ToHex>::to_hex(&self.0).as_ref())
+			}
+		}
+
+		impl<'a> Deserialize<'a> for $name {
+			fn deserialize<D>(deserializer: D) -> Result<Self, D::Error> where D: Deserializer<'a> {
+				struct HexBytesVisitor;
+
+				impl<'b> Visitor<'b> for HexBytesVisitor {
+					type Value = $name;
+
+					fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+						write!(formatter, "a hex-encoded bytes string")
+					}
+
+					fn visit_str<E>(self, value: &str) -> Result<Self::Value, E> where E: SerdeError {
+						if value.len() >= 2 && &value[0..2] == "0x" && value.len() & 1 == 0 {
+							impl_bytes_deserialize!($name, value, $from_hex)
+						} else {
+							Err(SerdeError::custom("invalid format"))
+						}
+					}
+
+					fn visit_string<E>(self, value: String) -> Result<Self::Value, E> where E: SerdeError {
+						self.visit_str(value.as_ref())
+					}
+				}
+
+				deserializer.deserialize_any(HexBytesVisitor)
+			}
+		}
+	}
+}
+
+/// Serializable message hash.
+pub type SerializableMessageHash = SerializableH256;
+/// Serializable address;
+pub type SerializableAddress = SerializableH160;
+
+impl_to_hex!(H256);
+impl_to_hex!(H160);
+impl_to_hex!(Public);
+
+impl_bytes!(SerializableBytes, Bytes, true, (Default));
+impl_bytes!(SerializableH256, H256, false, (Default, PartialOrd, Ord));
+impl_bytes!(SerializableH160, H160, false, (Default, PartialOrd, Ord));
+impl_bytes!(SerializablePublic, Public, false, (Default, PartialOrd, Ord));
+impl_bytes!(SerializableSecret, Secret, false, ());
+impl_bytes!(SerializableSignature, Signature, false, ());
+
+/// Serializable shadow decryption result.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct SerializableEncryptedDocumentKeyShadow {
+	/// Decrypted secret point. It is partially decrypted if shadow decryption was requested.
+	pub decrypted_secret: SerializablePublic,
+	/// Shared common point.
+	pub common_point: SerializablePublic,
+	/// If shadow decryption was requested: shadow decryption coefficients, encrypted with requestor public.
+	pub decrypt_shadows: Vec<SerializableBytes>,
+}
+
+/// Serializable requester identification data.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum SerializableRequester {
+	/// Requested with server key id signature.
+	Signature(SerializableSignature),
+	/// Requested with public key.
+	Public(SerializablePublic),
+	/// Requested with verified address.
+	Address(SerializableAddress),
+}
+
+impl From<SerializableRequester> for Requester {
+	fn from(requester: SerializableRequester) -> Requester {
+		match requester {
+			SerializableRequester::Signature(signature) => Requester::Signature(signature.into()),
+			SerializableRequester::Public(public) => Requester::Public(public.into()),
+			SerializableRequester::Address(address) => Requester::Address(address.into()),
+		}
+	}
+}
+
+impl From<Requester> for SerializableRequester {
+	fn from(requester: Requester) -> SerializableRequester {
+		match requester {
+			Requester::Signature(signature) => SerializableRequester::Signature(signature.into()),
+			Requester::Public(public) => SerializableRequester::Public(public.into()),
+			Requester::Address(address) => SerializableRequester::Address(address.into()),
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use serde_json;
+	use super::*;
+	use std::str::FromStr;
+
+	macro_rules! do_test {
+		($value: expr, $expected: expr, $expected_type: ident) => (
+			let serialized = serde_json::to_string(&$value).unwrap();
+			assert_eq!(serialized, $expected);
+			let deserialized: $expected_type = serde_json::from_str(&serialized).unwrap();
+			assert_eq!(deserialized, $value);
+		);
+	}
+
+	#[test]
+	fn serialize_and_deserialize_bytes() {
+		do_test!(SerializableBytes(vec![1, 2, 3, 4]), "\"0x01020304\"".to_owned(), SerializableBytes);
+	}
+
+	#[test]
+	fn serialize_and_deserialize_h256() {
+		let s = "5a39ed1020c04d4d84539975b893a4e7c53eab6c2965db8bc3468093a31bc5ae";
+		let h256 = SerializableH256(H256::from_str(s).unwrap());
+		do_test!(h256, format!("\"0x{}\"", s), SerializableH256);
+	}
+
+	#[test]
+	fn serialize_and_deserialize_h160() {
+		let s = "c6d9d2cd449a754c494264e1809c50e34d64562b";
+		let h160 = SerializableH160(H160::from_str(s).unwrap());
+		do_test!(h160, format!("\"0x{}\"", s), SerializableH160);
+	}
+
+	#[test]
+	fn serialize_and_deserialize_public() {
+		let s = "cac6c205eb06c8308d65156ff6c862c62b000b8ead121a4455a8ddeff7248128d895692136f240d5d1614dc7cc4147b1bd584bd617e30560bb872064d09ea325";
+		let public = SerializablePublic(s.parse().unwrap());
+		do_test!(public, format!("\"0x{}\"", s), SerializablePublic);
+	}
+
+	#[test]
+	fn serialize_and_deserialize_secret() {
+		let s = "5a39ed1020c04d4d84539975b893a4e7c53eab6c2965db8bc3468093a31bc5ae";
+		let secret = SerializableSecret(Secret::from_str(s).unwrap());
+		do_test!(secret, format!("\"0x{}\"", s), SerializableSecret);
+	}
+
+	#[test]
+	fn serialize_and_deserialize_signature() {
+		let raw_r = "afafafafafafafafafafafbcbcbcbcbcbcbcbcbcbeeeeeeeeeeeeedddddddddd";
+		let raw_s = "5a39ed1020c04d4d84539975b893a4e7c53eab6c2965db8bc3468093a31bc5ae";
+		let r = H256::from_str(raw_r).unwrap();
+		let s = H256::from_str(raw_s).unwrap();
+		let v = 42u8;
+		let public = SerializableSignature(Signature::from_rsv(&r, &s, v));
+		do_test!(public, format!("\"0x{}{}{:x}\"", raw_r, raw_s, v), SerializableSignature);
+	}
+}

--- a/primitives/src/service.rs
+++ b/primitives/src/service.rs
@@ -1,0 +1,79 @@
+// Copyright 2015-2020 Parity Technologies (UK) Ltd.
+// This file is part of Parity Secret Store.
+
+// Parity Secret Store is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity Secret Store is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity Secret Store.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::{collections::BTreeSet, sync::Arc};
+use ethereum_types::H256;
+use parity_crypto::publickey::{Public, Signature};
+use crate::{
+	ServerKeyId, KeyServerPublic,
+	key_server::{ServerKeyGenerationResult, DocumentKeyShadowRetrievalResult},
+	requester::Requester,
+};
+
+/// Service tasks listener registrar.
+pub trait ServiceTasksListenerRegistrar: Send + Sync {
+	/// Register service tasks listener.
+	fn register_listener(&self, listener: Arc<dyn ServiceTasksListener>);
+}
+
+/// Service tasks listener.
+///
+/// Service could subscribe to some key server events, so that it will
+/// receive notifications about all sessions that are completed on this
+/// node (even if they were started by another node).
+pub trait ServiceTasksListener: Send + Sync {
+	/// Called when server key generation session is completed.
+	fn server_key_generated(&self, _: ServerKeyGenerationResult) {}
+	/// Called when document key shadow is retrieved.
+	fn document_key_shadow_retrieved(&self, _: DocumentKeyShadowRetrievalResult) {}
+}
+
+/// Service contract task.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ServiceTask {
+	// === Server key related tasks ===
+
+	/// Generate server key (server_key_id, author, threshold).
+	GenerateServerKey(ServerKeyId, Requester, usize),
+	/// Retrieve server key (server_key_id, requester).
+	RetrieveServerKey(ServerKeyId, Option<Requester>),
+
+	// === Document key store tasks ===
+
+	/// Generate document key (server_key_id, author, threshold).
+	GenerateDocumentKey(ServerKeyId, Requester, usize),
+	/// Store document key (server_key_id, author, common_point, encrypted_point).
+	StoreDocumentKey(ServerKeyId, Requester, Public, Public),
+
+	// === Document key retrieval tasks ===
+
+	/// Retrieve document key (server_key_id, requester).
+	RetrieveDocumentKey(ServerKeyId, Requester),
+	/// Retrieve document key shadow (server_key_id, requester).
+	RetrieveShadowDocumentKey(ServerKeyId, Requester),
+
+	// === Signing tasks ===
+
+	/// Generate Schnorr signature for the message (server_key_id, requester, message).
+	SchnorrSignMessage(ServerKeyId, Requester, H256),
+	/// Generate ECDSA signature for the message.
+	EcdsaSignMessage(ServerKeyId, Requester, H256),
+
+	// === Administrative tasks ===
+
+	/// Change servers set (old_set_signature, new_set_signature, new_set).
+	ChangeServersSet(Signature, Signature, BTreeSet<KeyServerPublic>),
+}


### PR DESCRIPTION
This crate is currently not linked in any way to `key-server` folder (see #4  for explanation). Some notes on every extracted file and why it has been extracted:
- **acl_storage.rs**: we'll need to have different implementations for all supported blockchains => it isn't a part of a key`-server`. It also has in-memory implementation, which could be used in test mode (we have had this in parity-ethereum) or in tests;
- **error.rs**: to link different components together;
- **executor.rs**: original idea was to get rid of tokio, but it is too much refactoring for now. So there's a `trait Executor` for pieces of code that are tokio-agnostic and implementation (`type Tokio*`) based on tokio runtime that is compatible both with tokio 0.1 and 0.2 (network code in `key-server` still uses 0.1, and new `http-service` uses 0.2). I'll file an issue later about possible migration to single tokio, or tokio-agnostic runtime;
- **key_server_key_pair.rs**: in parity-ethereum we have had two implementations - one has been based on accounts secure storage and the second one has been in-memory. The latter one is introduced in this file (`InMemoryKeyServerKeyPair`), and the former should be implemented in final binaries;
- **key_server_set.rs**: this depends on blockchain => shouldn't be a part  of `key-server`. In-memory implementation (what has been called fixed key server set is also here - `InMemoryKeyServerSet`);
- **key_server.rs**: is the key server API. It has changed a bit, since different endpoints (services) may have different responses formats (i.e. in HTTP service we may want to encrypt data, while other endpoints may return data unencrypted);
- **key_storage.rs**: some binaries may have their own storages. In-memory storage (`InMemoryKeyStorage`) is also here. Not sure about rocksdb-based storage - whether we need separate crate for that, or it could be left in `key-server`. Will need to think on that;
- **requester.rs**: is a part of key server API;
- **serialization.rs**: questionable, because we only require this for `http-service` and `key-server`;
- **service.rs**: defines traits and enums required to implement SS service.