### PR TITLE
Introduce http service

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
+	"http-service",
 	"key-server",
 	"primitives",
 ]

--- a/http-service/Cargo.toml
+++ b/http-service/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "parity-secretstore-http-service"
+version = "1.0.0"
+license = "GPL-3.0"
+authors = ["Parity Technologies <admin@parity.io>"]
+edition = "2018"
+
+[dependencies]
+futures = "0.3"
+hyper = "0.13"
+jsonrpc-server-utils = "14.0"
+log = "0.4"
+percent-encoding = "2.1"
+serde = "1.0"
+serde_json = "1.0"
+primitives = { package = "parity-secretstore-primitives", path = "../primitives" }
+
+[dev-dependencies]
+assert_matches = "1.3"
+primitives = { package = "parity-secretstore-primitives", path = "../primitives", features = ["test-helpers"] }

--- a/http-service/src/lib.rs
+++ b/http-service/src/lib.rs
@@ -1,0 +1,873 @@
+// Copyright 2015-2020 Parity Technologies (UK) Ltd.
+// This file is part of Parity Secret Store.
+
+// Parity Secret Store is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity Secret Store is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity Secret Store.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::{future::Future, sync::Arc};
+use futures::future::{FutureExt, TryFutureExt, ready};
+use hyper::{
+	Body, Method, Request, Response, Server, StatusCode, Uri,
+	header::{self, HeaderValue},
+	service::{make_service_fn, service_fn},
+};
+use jsonrpc_server_utils::cors::{self, AllowCors, AccessControlAllowOrigin};
+use log::error;
+use serde::Serialize;
+use primitives::{
+	Public, ecies_encrypt,
+	error::Error as SecretStoreError,
+	key_server::{DocumentKeyStoreArtifacts, DocumentKeyShadowRetrievalArtifacts, KeyServer},
+	serialization::{SerializableBytes, SerializablePublic, SerializableEncryptedDocumentKeyShadow},
+	service::ServiceTask,
+};
+
+mod parse;
+
+type CorsDomains = Option<Vec<AccessControlAllowOrigin>>;
+
+/// All possible errors.
+#[derive(Debug)]
+pub enum Error {
+	/// Invalid listen address.
+	InvalidListenAddress(String),
+	/// Request has failed because of unauthorized Origin header.
+	InvalidCors,
+	/// Failed to parse HTTP request.
+	InvalidRequest,
+	/// Error from Hyper.
+	Hyper(hyper::Error),
+	/// Error from Secret Store.
+	SecretStore(SecretStoreError),
+}
+
+/// Decomposed HTTP request.
+#[derive(Debug, PartialEq)]
+pub struct DecomposedRequest {
+	/// Request URI.
+	pub uri: Uri,
+	/// Request method.
+	pub method: Method,
+	/// ORIGIN header field.
+	pub header_origin: Option<String>,
+	/// HOST header field.
+	pub header_host: Option<String>,
+	/// Request body.
+	pub body: Vec<u8>,
+}
+
+/// Start listening HTTP requests on given address.
+pub async fn start_service<KS: KeyServer>(
+	listen_address: &str,
+	listen_port: u16,
+	key_server: Arc<KS>,
+	cors: CorsDomains,
+) -> Result<(), Error> {
+	let cors = Arc::new(cors);
+	let http_address = format!("{}:{}", listen_address, listen_port)
+		.parse()
+		.map_err(|err: std::net::AddrParseError| Error::InvalidListenAddress(format!("{}", err)))?;
+	let http_server = Server::try_bind(&http_address)
+		.map_err(|err| Error::InvalidListenAddress(format!("{}", err)))?;
+	let http_service_fn = make_service_fn(move |_| {
+		let key_server = key_server.clone();
+		let cors = cors.clone();
+		async move {
+			Ok::<_, hyper::Error>(service_fn(
+				move |http_request| serve_http_request(
+					http_request,
+					key_server.clone(),
+					cors.clone(),
+				)
+			))
+		}
+	});
+	let http_service = http_server.serve(http_service_fn);
+	http_service.await.map_err(Error::Hyper)
+}
+
+/// Serve single HTTP request.
+async fn serve_http_request<KS: KeyServer>(
+	http_request: Request<Body>,
+	key_server: Arc<KS>,
+	cors_domains: Arc<CorsDomains>,
+) -> Result<Response<Body>, hyper::Error> {
+	match decompose_http_request(http_request).await {
+		Ok(decomposed_request) => serve_decomposed_http_request(
+			decomposed_request,
+			key_server,
+			cors_domains,
+		).await,
+		Err(error) => return Ok(return_error(error)),
+	}
+}
+
+/// Serve single decomposed HTTP request.
+async fn serve_decomposed_http_request<KS: KeyServer>(
+	decomposed_request: DecomposedRequest,
+	key_server: Arc<KS>,
+	cors_domains: Arc<CorsDomains>,
+) -> Result<Response<Body>, hyper::Error> {
+	let allow_cors = match ensure_cors(&decomposed_request, cors_domains) {
+		Ok(allow_cors) => allow_cors,
+		Err(error) => return Ok(return_error(error)),
+	};
+
+	let service_task = match crate::parse::parse_http_request(&decomposed_request) {
+		Ok(service_task) => service_task,
+		Err(error) => return Ok(return_error(error)),
+	};
+
+	serve_service_task(
+		decomposed_request,
+		key_server,
+		allow_cors,
+		service_task,
+	).await
+}
+
+/// Serve single service task.
+async fn serve_service_task<KS: KeyServer>(
+	decomposed_request: DecomposedRequest,
+	key_server: Arc<KS>,
+	allow_cors: AllowCors<AccessControlAllowOrigin>,
+	service_task: ServiceTask,
+) -> Result<Response<Body>, hyper::Error> {
+	let log_secret_store_error = |error| {
+		error!(
+			target: "secretstore",
+			"{} request {} has failed with: {}",
+			decomposed_request.method,
+			decomposed_request.uri,
+			error,
+		);
+
+		Error::SecretStore(error)
+	};
+
+	match service_task {
+		ServiceTask::GenerateServerKey(key_id, requester, threshold) =>
+			Ok(return_unencrypted_server_key(
+				&decomposed_request,
+				allow_cors,
+				key_server
+					.generate_key(None, key_id, requester, threshold)
+					.await
+					.map(|artifacts| artifacts.key)
+					.map_err(log_secret_store_error),
+			)),
+		ServiceTask::RetrieveServerKey(key_id, requester) =>
+			Ok(return_unencrypted_server_key(
+				&decomposed_request,
+				allow_cors,
+				key_server
+					.restore_key_public(
+						None,
+						key_id,
+						requester,
+					)
+					.await
+					.map(|artifacts| artifacts.key)
+					.map_err(log_secret_store_error),
+			)),
+		ServiceTask::GenerateDocumentKey(key_id, requester, threshold) =>
+			Ok(return_encrypted_document_key(
+				&decomposed_request,
+				allow_cors,
+				ready(requester.public(&key_id))
+					.and_then(|requester_public|
+						key_server
+							.generate_document_key(None, key_id, requester, threshold)
+							.map(Into::into)
+							.and_then(move |artifacts| ready(ecies_encrypt(
+								&requester_public,
+								artifacts.document_key.as_bytes(),
+							)))
+					)
+					.map_err(log_secret_store_error),
+			).await),
+		ServiceTask::StoreDocumentKey(key_id, requester, common_point, encrypted_point) =>
+			Ok(return_empty(
+				&decomposed_request,
+				allow_cors,
+				key_server
+					.store_document_key(None, key_id, requester, common_point, encrypted_point)
+					.await
+					.map(Into::into)
+					.map(|_: DocumentKeyStoreArtifacts| ())
+					.map_err(log_secret_store_error),
+			)),
+		ServiceTask::RetrieveDocumentKey(key_id, requester) =>
+			Ok(return_encrypted_document_key(
+				&decomposed_request,
+				allow_cors,
+				ready(requester.public(&key_id))
+					.and_then(|requester_public|
+						key_server
+							.restore_document_key(None, key_id, requester)
+							.map(Into::into)
+							.and_then(move |artifacts| ready(ecies_encrypt(
+								&requester_public,
+								artifacts.document_key.as_bytes(),
+							)))
+					)
+					.map_err(log_secret_store_error)
+			).await),
+		ServiceTask::RetrieveShadowDocumentKey(key_id, requester) =>
+			Ok(return_document_key_shadow(
+				&decomposed_request,
+				allow_cors,
+				key_server
+					.restore_document_key_shadow(None, key_id, requester)
+					.await
+					.map(Into::into)
+					.map_err(log_secret_store_error),
+			)),
+		ServiceTask::SchnorrSignMessage(key_id, requester, message_hash) =>
+			Ok(return_encrypted_message_signature(
+				&decomposed_request,
+				allow_cors,
+				ready(requester.public(&key_id))
+					.and_then(|requester_public|
+						key_server
+							.sign_message_schnorr(None, key_id, requester, message_hash)
+							.map(Into::into)
+							.and_then(|artifacts| {
+								let mut combined_signature = [0; 64];
+								combined_signature[..32].clone_from_slice(artifacts.signature_c.as_bytes());
+								combined_signature[32..].clone_from_slice(artifacts.signature_s.as_bytes());
+								ready(Ok(combined_signature))
+							})
+							.and_then(move |plain_signature| ready(ecies_encrypt(
+								&requester_public,
+								&plain_signature,
+							)))
+					)
+					.map_err(log_secret_store_error)
+			).await),
+		ServiceTask::EcdsaSignMessage(key_id, requester, message_hash) =>
+			Ok(return_encrypted_message_signature(
+				&decomposed_request,
+				allow_cors,
+				ready(requester.public(&key_id))
+					.and_then(|requester_public|
+						key_server
+							.sign_message_ecdsa(None, key_id, requester, message_hash)
+							.map(Into::into)
+							.and_then(move |artifacts| ready(ecies_encrypt(
+								&requester_public,
+								&*artifacts.signature,
+							)))
+					)
+					.map_err(log_secret_store_error)
+			).await),
+		ServiceTask::ChangeServersSet(old_set_signature, new_set_signature, new_set) =>
+			Ok(return_empty(
+				&decomposed_request,
+				allow_cors,
+				key_server
+					.change_servers_set(None, old_set_signature, new_set_signature, new_set)
+					.await
+					.map(Into::into)
+					.map_err(log_secret_store_error),
+			)),
+	}
+}
+
+/// Decompose single HTTP request.
+async fn decompose_http_request(
+	http_request: Request<Body>,
+) -> Result<DecomposedRequest, Error> {
+	let uri = http_request.uri().clone();
+	let method = http_request.method().clone();
+	let header_origin = http_request
+		.headers()
+		.get(header::ORIGIN)
+		.and_then(|value| value.to_str().ok())
+		.map(Into::into);
+	let header_host = http_request
+		.headers()
+		.get(header::HOST)
+		.and_then(|value| value.to_str().ok())
+		.map(Into::into);
+	let body = hyper::body::to_bytes(http_request.into_body())
+		.await
+		.map_err(|error| {
+			error!(
+				target: "secretstore",
+				"Failed to read body of {}-request {}: {}",
+				method,
+				uri,
+				error,
+			);
+
+			Error::Hyper(error)
+		})?.to_vec();
+
+	Ok(DecomposedRequest {
+		uri,
+		method,
+		header_origin,
+		header_host,
+		body,
+	})
+}
+
+/// Check CORS rules.
+fn ensure_cors(
+	request: &DecomposedRequest,
+	cors_domains: Arc<CorsDomains>,
+) -> Result<AllowCors<AccessControlAllowOrigin>, Error> {
+	let allow_cors = cors::get_cors_allow_origin(
+		request.header_origin.as_ref().map(|s| s.as_ref()),
+		request.header_host.as_ref().map(|s| s.as_ref()),
+		&*cors_domains,
+	);
+
+	match allow_cors {
+		AllowCors::Invalid => {
+			error!(
+				target: "secretstore",
+				"Ignoring {}-request {} with unauthorized Origin header",
+				request.method,
+				request.uri,
+			);
+
+			Err(Error::InvalidCors)
+		},
+		_ => Ok(allow_cors),
+	}
+}
+
+fn return_empty(
+	request: &DecomposedRequest,
+	allow_cors: AllowCors<AccessControlAllowOrigin>,
+	empty: Result<(), Error>,
+) -> Response<Body> {
+	return_bytes::<i32>(request, allow_cors, empty.map(|_| None))
+}
+
+fn return_unencrypted_server_key(
+	request: &DecomposedRequest,
+	allow_cors: AllowCors<AccessControlAllowOrigin>,
+	result: Result<Public, Error>,
+) -> Response<Body> {
+	return_bytes(request, allow_cors, result.map(|key| Some(SerializablePublic(key))))
+}
+
+async fn return_encrypted_document_key(
+	request: &DecomposedRequest,
+	allow_cors: AllowCors<AccessControlAllowOrigin>,
+	encrypted_document_key: impl Future<Output=Result<Vec<u8>, Error>>,
+) -> Response<Body> {
+	return_bytes(
+		request,
+		allow_cors,
+		encrypted_document_key
+			.await
+			.map(|key| Some(SerializableBytes(key))),
+	)
+}
+
+fn return_document_key_shadow(
+	request: &DecomposedRequest,
+	allow_cors: AllowCors<AccessControlAllowOrigin>,
+	document_key_shadow: Result<DocumentKeyShadowRetrievalArtifacts, Error>,
+) -> Response<Body> {
+	return_bytes(request, allow_cors, document_key_shadow.map(|k| Some(SerializableEncryptedDocumentKeyShadow {
+		decrypted_secret: k.encrypted_document_key.into(),
+		common_point: k.common_point.into(),
+		decrypt_shadows: k
+			.participants_coefficients
+			.values()
+			.cloned()
+			.map(Into::into)
+			.collect(),
+	})))
+}
+
+async fn return_encrypted_message_signature(
+	request: &DecomposedRequest,
+	allow_cors: AllowCors<AccessControlAllowOrigin>,
+	encrypted_signature: impl Future<Output=Result<Vec<u8>, Error>>,
+) -> Response<Body> {
+	return_bytes(
+		request,
+		allow_cors,
+		encrypted_signature
+			.await
+			.map(|s| Some(SerializableBytes(s))),
+	)
+}
+
+fn return_bytes<T: Serialize>(
+	request: &DecomposedRequest,
+	allow_cors: AllowCors<AccessControlAllowOrigin>,
+	result: Result<Option<T>, Error>,
+) -> Response<Body> {
+	match result {
+		Ok(Some(result)) => match serde_json::to_vec(&result) {
+			Ok(result) => {
+				let body: Body = result.into();
+				let mut builder = Response::builder();
+				builder = builder.header(
+					header::CONTENT_TYPE,
+					HeaderValue::from_static("application/json; charset=utf-8"),
+				);
+				if let AllowCors::Ok(AccessControlAllowOrigin::Value(origin)) = allow_cors {
+					builder = builder.header(header::ACCESS_CONTROL_ALLOW_ORIGIN, origin.to_string());
+				}
+				builder.body(body).expect("Error creating http response")
+			},
+			Err(err) => {
+				error!(target: "secretstore", "Response to request {} has failed with: {}", request.uri, err);
+				Response::builder()
+					.status(StatusCode::INTERNAL_SERVER_ERROR)
+					.body(Body::empty())
+					.expect("Nothing to parse, cannot fail; qed")
+			}
+		},
+		Ok(None) => {
+			let mut builder = Response::builder();
+			builder = builder.status(StatusCode::OK);
+			if let AllowCors::Ok(AccessControlAllowOrigin::Value(origin)) = allow_cors {
+				builder = builder.header(header::ACCESS_CONTROL_ALLOW_ORIGIN, origin.to_string());
+			}
+			builder.body(Body::empty()).expect("Nothing to parse, cannot fail; qed")
+		},
+		Err(err) => return_error(err),
+	}
+}
+
+fn return_error(err: Error) -> Response<Body> {
+	let status = match err {
+		Error::SecretStore(SecretStoreError::AccessDenied)
+		| Error::SecretStore(SecretStoreError::ConsensusUnreachable)
+		| Error::SecretStore(SecretStoreError::ConsensusTemporaryUnreachable) =>
+			StatusCode::FORBIDDEN,
+		| Error::SecretStore(SecretStoreError::ServerKeyIsNotFound)
+		| Error::SecretStore(SecretStoreError::DocumentKeyIsNotFound) =>
+			StatusCode::NOT_FOUND,
+		Error::InvalidCors
+		| Error::InvalidRequest
+		| Error::SecretStore(SecretStoreError::InsufficientRequesterData(_))
+		| Error::Hyper(_)
+		| Error::SecretStore(SecretStoreError::Hyper(_))
+		| Error::SecretStore(SecretStoreError::Serde(_))
+		| Error::SecretStore(SecretStoreError::DocumentKeyAlreadyStored)
+		| Error::SecretStore(SecretStoreError::ServerKeyAlreadyGenerated) =>
+			StatusCode::BAD_REQUEST,
+		_ => StatusCode::INTERNAL_SERVER_ERROR,
+	};
+
+	let mut res = Response::builder();
+	res = res.status(status);
+
+	// return error text. ignore errors when returning error
+	let error_text = format!("\"{}\"", err);
+	if let Ok(error_text) = serde_json::to_vec(&error_text) {
+		res = res.header(header::CONTENT_TYPE, HeaderValue::from_static("application/json; charset=utf-8"));
+		res.body(error_text.into())
+			.expect("`error_text` is a formatted string, parsing cannot fail; qed")
+	} else {
+		res.body(Body::empty())
+			.expect("Nothing to parse, cannot fail; qed")
+	}
+}
+
+impl std::fmt::Display for Error {
+	fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
+		match *self {
+			Error::InvalidListenAddress(ref msg) => write!(f, "Invalid listen address: {}", msg),
+			Error::InvalidCors => write!(f, "Request with unauthorized Origin header"),
+			Error::InvalidRequest => write!(f, "Failed to parse request"),
+			Error::Hyper(ref error) => write!(f, "Internal server error: {}", error),
+			Error::SecretStore(ref error) => write!(f, "Secret store error: {}", error),
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use assert_matches::assert_matches;
+	use primitives::{requester::Requester, key_server::AccumulatingKeyServer};
+	use super::*;
+
+	fn default_decomposed_request() -> DecomposedRequest {
+		DecomposedRequest {
+			uri: "http://some-uri/generate-server-key".parse().unwrap(),
+			method: Method::POST,
+			header_origin: Some("some-origin".into()),
+			header_host: Some("some-host".into()),
+			body: "Hello, world!".bytes().collect(),
+		}
+	}
+
+	fn assert_access_denied_response(response: Response<Body>) {
+		assert_eq!(response.status(), StatusCode::FORBIDDEN);
+		assert_eq!(
+			futures::executor::block_on(hyper::body::to_bytes(response.into_body())).unwrap(),
+			serde_json::to_vec(&format!("\"{}\"", Error::SecretStore(SecretStoreError::AccessDenied))).unwrap(),
+		);
+	}
+
+	#[test]
+	fn decompose_http_request_works() {
+		assert_eq!(
+			futures::executor::block_on(decompose_http_request(
+				Request::builder()
+					.uri("http://some-uri/generate-server-key")
+					.method(Method::POST)
+					.header(header::ORIGIN, "some-origin")
+					.header(header::HOST, "some-host")
+					.body(Body::wrap_stream(
+						futures::stream::iter(
+							vec![Result::<_, std::io::Error>::Ok("Hello, world!")],
+					)))
+					.unwrap()
+			)).unwrap(),
+			default_decomposed_request(),
+		);
+	}
+
+	#[test]
+	fn decompose_http_request_fails() {
+		assert_matches!(
+			futures::executor::block_on(decompose_http_request(
+				Request::builder()
+					.body(Body::wrap_stream(
+						futures::stream::iter(
+							vec![Result::<&'static str, _>::Err(
+								std::io::Error::new(std::io::ErrorKind::Other, "Test error"),
+							)],
+						)
+					))
+					.unwrap()
+			)),
+			Err(Error::Hyper(_))
+		);
+	}
+
+	#[test]
+	fn ensure_cors_works() {
+		let mut request = default_decomposed_request();
+		assert_matches!(ensure_cors(&request, Arc::new(None)), Ok(_));
+		request.header_origin = None;
+		assert_matches!(
+			ensure_cors(&request, Arc::new(Some(vec![AccessControlAllowOrigin::Null]))),
+			Ok(_)
+		);
+	}
+
+	#[test]
+	fn ensure_cors_fails() {
+		assert_matches!(
+			ensure_cors(
+				&default_decomposed_request(),
+				Arc::new(Some(vec![
+					AccessControlAllowOrigin::Value("xxx".into()),
+				])),
+			),
+			Err(Error::InvalidCors)
+		);
+	}
+
+	#[test]
+	fn return_empty_ok_works() {
+		let response = return_empty(
+			&default_decomposed_request(),
+			AllowCors::NotRequired,
+			Ok(()),
+		);
+		assert_eq!(response.status(), StatusCode::OK);
+		assert_eq!(
+			futures::executor::block_on(hyper::body::to_bytes(response.into_body())).unwrap(),
+			Vec::new(),
+		);
+	}
+
+	#[test]
+	fn return_empty_err_works() {
+		assert_access_denied_response(return_empty(
+			&default_decomposed_request(),
+			AllowCors::NotRequired,
+			Err(Error::SecretStore(SecretStoreError::AccessDenied)),
+		));
+	}
+
+	#[test]
+	fn return_unencrypted_server_key_ok_works() {
+		let response = return_unencrypted_server_key(
+			&default_decomposed_request(),
+			AllowCors::NotRequired,
+			Ok([1u8; 64].into()),
+		);
+		assert_eq!(response.status(), StatusCode::OK);
+		assert_eq!(
+			futures::executor::block_on(hyper::body::to_bytes(response.into_body())).unwrap(),
+			"\"0x01010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101\"",
+		);
+	}
+
+	#[test]
+	fn return_unencrypted_server_key_err_works() {
+		assert_access_denied_response(return_unencrypted_server_key(
+			&default_decomposed_request(),
+			AllowCors::NotRequired,
+			Err(Error::SecretStore(SecretStoreError::AccessDenied)),
+		));
+	}
+
+	#[test]
+	fn return_encrypted_document_key_ok_works() {
+		let response = futures::executor::block_on(
+			return_encrypted_document_key(
+				&default_decomposed_request(),
+				AllowCors::NotRequired,
+				ready(Ok(vec![0x42])),
+			)
+		);
+		assert_eq!(response.status(), StatusCode::OK);
+		assert_eq!(
+			futures::executor::block_on(hyper::body::to_bytes(response.into_body())).unwrap(),
+			"\"0x42\"",
+		);
+	}
+
+	#[test]
+	fn return_encrypted_document_key_err_works() {
+		assert_access_denied_response(futures::executor::block_on(
+			return_encrypted_document_key(
+				&default_decomposed_request(),
+				AllowCors::NotRequired,
+				ready(Err(Error::SecretStore(SecretStoreError::AccessDenied))),
+			)
+		));
+	}
+
+	#[test]
+	fn return_document_key_shadow_ok_works() {
+		let response = return_document_key_shadow(
+			&default_decomposed_request(),
+			AllowCors::NotRequired,
+			Ok(DocumentKeyShadowRetrievalArtifacts {
+				common_point: [1u8; 64].into(),
+				threshold: 42,
+				encrypted_document_key: [2u8; 64].into(),
+				participants_coefficients: vec![
+					([1u8; 20].into(), vec![0x42]),
+					([2u8; 20].into(), vec![0x43]),
+				].into_iter().collect(),
+			}),
+		);
+		assert_eq!(response.status(), StatusCode::OK);
+		assert_eq!(
+			futures::executor::block_on(hyper::body::to_bytes(response.into_body())).unwrap(),
+			"{\
+				\"decrypted_secret\":\"0x02020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202\",\
+				\"common_point\":\"0x01010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101\",\
+				\"decrypt_shadows\":[\"0x42\",\"0x43\"]\
+			}",
+		);
+	}
+
+	#[test]
+	fn return_document_key_shadow_err_works() {
+		assert_access_denied_response(return_document_key_shadow(
+			&default_decomposed_request(),
+			AllowCors::NotRequired,
+			Err(Error::SecretStore(SecretStoreError::AccessDenied)),
+		));
+	}
+
+	#[test]
+	fn return_encrypted_message_signature_ok_works() {
+		let response = futures::executor::block_on(
+			return_encrypted_message_signature(
+				&default_decomposed_request(),
+				AllowCors::NotRequired,
+				ready(Ok(vec![0x42])),
+			)
+		);
+		assert_eq!(response.status(), StatusCode::OK);
+		assert_eq!(
+			futures::executor::block_on(hyper::body::to_bytes(response.into_body())).unwrap(),
+			"\"0x42\"",
+		);
+	}
+
+	#[test]
+	fn return_encrypted_message_signature_err_works() {
+		assert_access_denied_response(futures::executor::block_on(
+			return_encrypted_message_signature(
+				&default_decomposed_request(),
+				AllowCors::NotRequired,
+				ready(Err(Error::SecretStore(SecretStoreError::AccessDenied))),
+			)
+		));
+	}
+
+	#[test]
+	fn serve_decomposed_http_request_schedules_generate_server_key_request() {
+		let key_server = Arc::new(AccumulatingKeyServer::default());
+		let service_task = ServiceTask::GenerateServerKey(
+			[1u8; 32].into(),
+			Requester::Address([2u8; 20].into()),
+			42,
+		);
+		futures::executor::block_on(serve_service_task(
+			default_decomposed_request(),
+			key_server.clone(),
+			AllowCors::NotRequired,
+			service_task.clone(),
+		)).unwrap();
+		assert_eq!(key_server.accumulated_tasks(), vec![service_task]);
+	}
+
+	#[test]
+	fn serve_decomposed_http_request_schedules_retrieve_server_key_request() {
+		let key_server = Arc::new(AccumulatingKeyServer::default());
+		let service_task = ServiceTask::RetrieveServerKey(
+			[1u8; 32].into(),
+			Some(Requester::Address([2u8; 20].into())),
+		);
+		futures::executor::block_on(serve_service_task(
+			default_decomposed_request(),
+			key_server.clone(),
+			AllowCors::NotRequired,
+			service_task.clone(),
+		)).unwrap();
+		assert_eq!(key_server.accumulated_tasks(), vec![service_task]);
+	}
+
+	#[test]
+	fn serve_decomposed_http_request_schedules_generate_document_key_request() {
+		let key_server = Arc::new(AccumulatingKeyServer::default());
+		let service_task = ServiceTask::GenerateDocumentKey(
+			[1u8; 32].into(),
+			Requester::Public([2u8; 64].into()),
+			42,
+		);
+		futures::executor::block_on(serve_service_task(
+			default_decomposed_request(),
+			key_server.clone(),
+			AllowCors::NotRequired,
+			service_task.clone(),
+		)).unwrap();
+		assert_eq!(key_server.accumulated_tasks(), vec![service_task]);
+	}
+
+	#[test]
+	fn serve_decomposed_http_request_schedules_store_document_key_request() {
+		let key_server = Arc::new(AccumulatingKeyServer::default());
+		let service_task = ServiceTask::StoreDocumentKey(
+			[1u8; 32].into(),
+			Requester::Public([2u8; 64].into()),
+			[3u8; 64].into(),
+			[4u8; 64].into(),
+		);
+		futures::executor::block_on(serve_service_task(
+			default_decomposed_request(),
+			key_server.clone(),
+			AllowCors::NotRequired,
+			service_task.clone(),
+		)).unwrap();
+		assert_eq!(key_server.accumulated_tasks(), vec![service_task]);
+	}
+
+	#[test]
+	fn serve_decomposed_http_request_schedules_retrieve_document_key_request() {
+		let key_server = Arc::new(AccumulatingKeyServer::default());
+		let service_task = ServiceTask::RetrieveDocumentKey(
+			[1u8; 32].into(),
+			Requester::Public([2u8; 64].into()),
+		);
+		futures::executor::block_on(serve_service_task(
+			default_decomposed_request(),
+			key_server.clone(),
+			AllowCors::NotRequired,
+			service_task.clone(),
+		)).unwrap();
+		assert_eq!(key_server.accumulated_tasks(), vec![service_task]);
+	}
+
+	#[test]
+	fn serve_decomposed_http_request_schedules_retrieve_document_key_shadow_request() {
+		let key_server = Arc::new(AccumulatingKeyServer::default());
+		let service_task = ServiceTask::RetrieveShadowDocumentKey(
+			[1u8; 32].into(),
+			Requester::Public([2u8; 64].into()),
+		);
+		futures::executor::block_on(serve_service_task(
+			default_decomposed_request(),
+			key_server.clone(),
+			AllowCors::NotRequired,
+			service_task.clone(),
+		)).unwrap();
+		assert_eq!(key_server.accumulated_tasks(), vec![service_task]);
+	}
+
+	#[test]
+	fn serve_decomposed_http_request_schedules_schnorr_sign_message_request() {
+		let key_server = Arc::new(AccumulatingKeyServer::default());
+		let service_task = ServiceTask::SchnorrSignMessage(
+			[1u8; 32].into(),
+			Requester::Public([2u8; 64].into()),
+			[3u8; 32].into(),
+		);
+		futures::executor::block_on(serve_service_task(
+			default_decomposed_request(),
+			key_server.clone(),
+			AllowCors::NotRequired,
+			service_task.clone(),
+		)).unwrap();
+		assert_eq!(key_server.accumulated_tasks(), vec![service_task]);
+	}
+
+	#[test]
+	fn serve_decomposed_http_request_schedules_ecdsa_sign_message_request() {
+		let key_server = Arc::new(AccumulatingKeyServer::default());
+		let service_task = ServiceTask::EcdsaSignMessage(
+			[1u8; 32].into(),
+			Requester::Public([2u8; 64].into()),
+			[3u8; 32].into(),
+		);
+		futures::executor::block_on(serve_service_task(
+			default_decomposed_request(),
+			key_server.clone(),
+			AllowCors::NotRequired,
+			service_task.clone(),
+		)).unwrap();
+		assert_eq!(key_server.accumulated_tasks(), vec![service_task]);
+	}
+
+	#[test]
+	fn serve_decomposed_http_request_schedules_change_servers_set_request() {
+		let key_server = Arc::new(AccumulatingKeyServer::default());
+		let service_task = ServiceTask::ChangeServersSet(
+			[1u8; 65].into(),
+			[2u8; 65].into(),
+			vec![
+				[3u8; 64].into(),
+				[4u8; 64].into(),
+			].into_iter().collect(),
+		);
+		futures::executor::block_on(serve_service_task(
+			default_decomposed_request(),
+			key_server.clone(),
+			AllowCors::NotRequired,
+			service_task.clone(),
+		)).unwrap();
+		assert_eq!(key_server.accumulated_tasks(), vec![service_task]);
+	}
+}

--- a/http-service/src/parse.rs
+++ b/http-service/src/parse.rs
@@ -1,0 +1,319 @@
+// Copyright 2015-2020 Parity Technologies (UK) Ltd.
+// This file is part of Parity Secret Store.
+
+// Parity Secret Store is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity Secret Store is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity Secret Store.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::collections::BTreeSet;
+use hyper::Method;
+use primitives::{service::ServiceTask, requester::Requester, serialization::SerializablePublic};
+use crate::{DecomposedRequest, Error};
+
+pub fn parse_http_request(request: &DecomposedRequest) -> Result<ServiceTask, Error> {
+	let uri_path = request.uri.path().to_string();
+	let uri_path = percent_encoding::percent_decode(uri_path.as_bytes())
+		.decode_utf8()
+		.map_err(|_| Error::InvalidRequest)?;
+
+	let path: Vec<String> = uri_path.trim_start_matches('/').split('/').map(Into::into).collect();
+	if path.len() == 0 {
+		return Err(Error::InvalidRequest);
+	}
+
+	if path[0] == "admin" {
+		return parse_admin_request(request, path);
+	}
+
+	let is_known_prefix = &path[0] == "shadow" || &path[0] == "schnorr" || &path[0] == "ecdsa" || &path[0] == "server";
+	let (prefix, args_offset) = if is_known_prefix { (&*path[0], 1) } else { ("", 0) };
+	let args_count = path.len() - args_offset;
+	if args_count < 2 || path[args_offset].is_empty() || path[args_offset + 1].is_empty() {
+		return Err(Error::InvalidRequest);
+	}
+
+	let document = match path[args_offset].parse() {
+		Ok(document) => document,
+		_ => return Err(Error::InvalidRequest),
+	};
+	let signature = match path[args_offset + 1].parse() {
+		Ok(signature) => signature,
+		_ => return Err(Error::InvalidRequest),
+	};
+	let signature = Requester::Signature(signature);
+
+	let threshold = path.get(args_offset + 2).map(|v| v.parse());
+	let message_hash = path.get(args_offset + 2).map(|v| v.parse());
+	let common_point = path.get(args_offset + 2).map(|v| v.parse());
+	let encrypted_key = path.get(args_offset + 3).map(|v| v.parse());
+	match (prefix, args_count, &request.method, threshold, message_hash, common_point, encrypted_key) {
+		("shadow", 3, &Method::POST, Some(Ok(threshold)), _, _, _) =>
+			Ok(ServiceTask::GenerateServerKey(document, signature, threshold)),
+		("shadow", 4, &Method::POST, _, _, Some(Ok(common_point)), Some(Ok(encrypted_key))) =>
+			Ok(ServiceTask::StoreDocumentKey(document, signature, common_point, encrypted_key)),
+		("", 3, &Method::POST, Some(Ok(threshold)), _, _, _) =>
+			Ok(ServiceTask::GenerateDocumentKey(document, signature, threshold)),
+		("server", 2, &Method::GET, _, _, _, _) =>
+			Ok(ServiceTask::RetrieveServerKey(document, Some(signature))),
+		("", 2, &Method::GET, _, _, _, _) =>
+			Ok(ServiceTask::RetrieveDocumentKey(document, signature)),
+		("shadow", 2, &Method::GET, _, _, _, _) =>
+			Ok(ServiceTask::RetrieveShadowDocumentKey(document, signature)),
+		("schnorr", 3, &Method::GET, _, Some(Ok(message_hash)), _, _) =>
+			Ok(ServiceTask::SchnorrSignMessage(document, signature, message_hash)),
+		("ecdsa", 3, &Method::GET, _, Some(Ok(message_hash)), _, _) =>
+			Ok(ServiceTask::EcdsaSignMessage(document, signature, message_hash)),
+		_ => Err(Error::InvalidRequest),
+	}
+}
+
+fn parse_admin_request(request: &DecomposedRequest, path: Vec<String>) -> Result<ServiceTask, Error> {
+	let args_count = path.len();
+	if request.method != Method::POST || args_count != 4 || path[1] != "servers_set_change" {
+		return Err(Error::InvalidRequest);
+	}
+
+	let old_set_signature = match path[2].parse() {
+		Ok(signature) => signature,
+		_ => return Err(Error::InvalidRequest),
+	};
+
+	let new_set_signature = match path[3].parse() {
+		Ok(signature) => signature,
+		_ => return Err(Error::InvalidRequest),
+	};
+
+	let new_servers_set: BTreeSet<SerializablePublic> = match serde_json::from_slice(&request.body) {
+		Ok(new_servers_set) => new_servers_set,
+		_ => return Err(Error::InvalidRequest),
+	};
+
+	Ok(ServiceTask::ChangeServersSet(old_set_signature, new_set_signature,
+		new_servers_set.into_iter().map(Into::into).collect()))
+}
+
+#[cfg(test)]
+mod tests {
+	use std::str::FromStr;
+	use assert_matches::assert_matches;
+	use hyper::Uri;
+	use primitives::ServerKeyId;
+	use super::*;
+
+	const KEY_ID_ENCODED: &'static str = "%30000000000000000000000000000000000000000000000000000000000000001";
+	const KEY_ID: &'static str = "0000000000000000000000000000000000000000000000000000000000000001";
+	const SIGNATURE: &'static str = "a199fb39e11eefb61c78a4074a53c0d4424600a3e74aad4fb9d93a26c30d067e\
+		1d4d29936de0c73f19827394a1dd049480a0d581aee7ae7546968da7d3d1c2fd01";
+	const THRESHOLD: &'static str = "2";
+	const COMMON_POINT: &'static str = "b486d3840218837b035c66196ecb15e6b067ca20101e11bd5e626288ab6806\
+		ecc70b8307012626bd512bad1559112d11d21025cef48cc7a1d2f3976da08f36c8";
+	const ENCRYPTED_POINT: &'static str = "1395568277679f7f583ab7c0992da35f26cde57149ee70e524e49bdae62d\
+		b3e18eb96122501e7cbb798b784395d7bb5a499edead0706638ad056d886e56cf8fb";
+	const MESSAGE_HASH: &'static str = "281b6bf43cb86d0dc7b98e1b7def4a80f3ce16d28d2308f934f116767306f06c";
+	const NODE1: &'static str = "843645726384530ffb0c52f175278143b5a93959af7864460f5a4fe\
+		c9afd1450cfb8aef63dec90657f43f55b13e0a73c7524d4e9a13c051b4e5f1e53f39ecd91";
+	const NODE2: &'static str = "07230e34ebfe41337d3ed53b186b3861751f2401ee74b988bba5569\
+		4e2a6f60c757677e194be2e53c3523cc8548694e636e6acb35c4e8fdc5e29d28679b9b2f3";
+	const OLD_SET_SIGNATURE: &'static str = "a199fb39e11eefb61c78a4074a53c0d4424600a3e74aad4fb9d93a26\
+		c30d067e1d4d29936de0c73f19827394a1dd049480a0d581aee7ae7546968da7d3d1c2fd01";
+	const NEW_SET_SIGNATURE: &'static str = "b199fb39e11eefb61c78a4074a53c0d4424600a3e74aad4fb9d93a26\
+		c30d067e1d4d29936de0c73f19827394a1dd049480a0d581aee7ae7546968da7d3d1c2fd01";
+
+
+	fn prepare_request(method: Method, uri_path: String) -> DecomposedRequest {
+		DecomposedRequest {
+			uri: Uri::builder().path_and_query(uri_path.as_str()).build().unwrap(),
+			method,
+			header_origin: None,
+			header_host: None,
+			body: Vec::new(),
+		}
+	}
+
+	#[test]
+	fn parse_http_request_successful() {
+		assert_eq!(
+			parse_http_request(&prepare_request(
+				Method::POST,
+				format!("/shadow/{}/{}/{}", KEY_ID, SIGNATURE, THRESHOLD),
+			)).unwrap(),
+			ServiceTask::GenerateServerKey(
+				ServerKeyId::from_str(KEY_ID).unwrap(),
+				Requester::Signature(SIGNATURE.parse().unwrap()),
+				THRESHOLD.parse().unwrap(),
+		));
+		assert_eq!(
+			parse_http_request(&prepare_request(
+				Method::POST,
+				format!("/shadow/{}/{}/{}/{}", KEY_ID, SIGNATURE, COMMON_POINT, ENCRYPTED_POINT),
+			)).unwrap(),
+			ServiceTask::StoreDocumentKey(
+				ServerKeyId::from_str(KEY_ID).unwrap(),
+				Requester::Signature(SIGNATURE.parse().unwrap()),
+				COMMON_POINT.parse().unwrap(),
+				ENCRYPTED_POINT.parse().unwrap(),
+		));
+		assert_eq!(
+			parse_http_request(&prepare_request(
+				Method::POST,
+				format!("/{}/{}/{}", KEY_ID, SIGNATURE, THRESHOLD),
+			)).unwrap(),
+			ServiceTask::GenerateDocumentKey(
+				ServerKeyId::from_str(KEY_ID).unwrap(),
+				Requester::Signature(SIGNATURE.parse().unwrap()),
+				THRESHOLD.parse().unwrap(),
+		));
+		assert_eq!(
+			parse_http_request(&prepare_request(
+				Method::GET,
+				format!("/server/{}/{}", KEY_ID, SIGNATURE),
+			)).unwrap(),
+			ServiceTask::RetrieveServerKey(
+				ServerKeyId::from_str(KEY_ID).unwrap(),
+				Some(Requester::Signature(SIGNATURE.parse().unwrap())),
+		));
+		assert_eq!(
+			parse_http_request(&prepare_request(
+				Method::GET,
+				format!("/{}/{}", KEY_ID, SIGNATURE),
+			)).unwrap(),
+			ServiceTask::RetrieveDocumentKey(
+				ServerKeyId::from_str(KEY_ID).unwrap(),
+				Requester::Signature(SIGNATURE.parse().unwrap()),
+		));
+		assert_eq!(
+			parse_http_request(&prepare_request(
+				Method::GET,
+				format!("/{}/{}", KEY_ID_ENCODED, SIGNATURE),
+			)).unwrap(),
+			ServiceTask::RetrieveDocumentKey(
+				ServerKeyId::from_str(KEY_ID).unwrap(),
+				Requester::Signature(SIGNATURE.parse().unwrap()),
+		));
+		assert_eq!(
+			parse_http_request(&prepare_request(
+				Method::GET,
+				format!("/shadow/{}/{}", KEY_ID, SIGNATURE),
+			)).unwrap(),
+			ServiceTask::RetrieveShadowDocumentKey(
+				ServerKeyId::from_str(KEY_ID).unwrap(),
+				Requester::Signature(SIGNATURE.parse().unwrap()),
+		));
+		assert_eq!(
+			parse_http_request(&prepare_request(
+				Method::GET,
+				format!("/schnorr/{}/{}/{}", KEY_ID, SIGNATURE, MESSAGE_HASH),
+			)).unwrap(),
+			ServiceTask::SchnorrSignMessage(
+				ServerKeyId::from_str(KEY_ID).unwrap(),
+				Requester::Signature(SIGNATURE.parse().unwrap()),
+				MESSAGE_HASH.parse().unwrap(),
+		));
+		assert_eq!(
+			parse_http_request(&prepare_request(
+				Method::GET,
+				format!("/ecdsa/{}/{}/{}", KEY_ID, SIGNATURE, MESSAGE_HASH),
+			)).unwrap(),
+			ServiceTask::EcdsaSignMessage(
+				ServerKeyId::from_str(KEY_ID).unwrap(),
+				Requester::Signature(SIGNATURE.parse().unwrap()),
+				MESSAGE_HASH.parse().unwrap(),
+		));
+
+		let mut servers_set_change_request = prepare_request(
+			Method::POST,
+			format!("/admin/servers_set_change/{}/{}", OLD_SET_SIGNATURE, NEW_SET_SIGNATURE),
+		);
+		servers_set_change_request.body = format!("[\"0x{}\",\"0x{}\"]", NODE1, NODE2).as_bytes().to_vec();
+				assert_eq!(
+			parse_http_request(&servers_set_change_request).unwrap(),
+			ServiceTask::ChangeServersSet(
+				OLD_SET_SIGNATURE.parse().unwrap(),
+				NEW_SET_SIGNATURE.parse().unwrap(),
+				vec![NODE1.parse().unwrap(), NODE2.parse().unwrap()].into_iter().collect(),
+		));
+	}
+
+	#[test]
+	fn parse_request_failed() {
+		assert_matches!(
+			parse_http_request(&prepare_request(
+				Method::GET,
+				format!(""),
+			)).unwrap_err(),
+			Error::InvalidRequest
+		);
+		assert_matches!(
+			parse_http_request(&prepare_request(
+				Method::GET,
+				format!("/shadow"),
+			)).unwrap_err(),
+			Error::InvalidRequest
+		);
+		assert_matches!(
+			parse_http_request(&prepare_request(
+				Method::GET,
+				format!("///2"),
+			)).unwrap_err(),
+			Error::InvalidRequest
+		);
+		assert_matches!(
+			parse_http_request(&prepare_request(
+				Method::GET,
+				format!("/shadow///2"),
+			)).unwrap_err(),
+			Error::InvalidRequest
+		);
+		assert_matches!(
+			parse_http_request(&prepare_request(
+				Method::GET,
+				format!("/{}", KEY_ID),
+			)).unwrap_err(),
+			Error::InvalidRequest
+		);
+		assert_matches!(
+			parse_http_request(&prepare_request(
+				Method::GET,
+				format!("/{}/", KEY_ID),
+			)).unwrap_err(),
+			Error::InvalidRequest
+		);
+		assert_matches!(
+			parse_http_request(&prepare_request(
+				Method::GET,
+				format!("/a/b"),
+			)).unwrap_err(),
+			Error::InvalidRequest
+		);
+		assert_matches!(
+			parse_http_request(&prepare_request(
+				Method::GET,
+				format!("/schnorr/{}/{}/{}/{}", KEY_ID, SIGNATURE, MESSAGE_HASH, THRESHOLD),
+			)).unwrap_err(),
+			Error::InvalidRequest
+		);
+		assert_matches!(
+			parse_http_request(&prepare_request(
+				Method::GET,
+				format!("/ecdsa/{}/{}/{}/{}", KEY_ID, SIGNATURE, MESSAGE_HASH, THRESHOLD),
+			)).unwrap_err(),
+			Error::InvalidRequest
+		);
+		assert_matches!(
+			parse_http_request(&prepare_request(
+				Method::POST,
+				format!("/admin/servers_set_change/{}/{}", OLD_SET_SIGNATURE, NEW_SET_SIGNATURE),
+			)).unwrap_err(),
+			Error::InvalidRequest
+		);
+	}
+}

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -18,3 +18,6 @@ tokio-compat = { version = "0.1", features = ["rt-full"] }
 
 [dev-dependencies]
 serde_json = "1.0"
+
+[features]
+test-helpers = []


### PR DESCRIPTION
part of #4 

HTTP-service takes `impl KeyServer` as argument and translates incoming HTTP requests into corresponding `KeyServer` calls. It is the [`http_listener.rs`](https://github.com/paritytech/secret-store/blob/988aaad85619564120ab0d1657f749b3df7b95d7/key-server/src/listener/http_listener.rs) file that is migrated to support new `hyper` and new `KeyServer` interface. Besides that, it also has more tests than its predecessor.