### PR TITLE
Migrate key-server to 2018 edition

### DIFF
--- a/key-server/Cargo.toml
+++ b/key-server/Cargo.toml
@@ -4,6 +4,7 @@ name = "parity-secretstore"
 version = "1.0.0"
 license = "GPL-3.0"
 authors = ["Parity Technologies <admin@parity.io>"]
+edition = "2018"
 
 [dependencies]
 byteorder = "1.0"

--- a/key-server/src/acl_storage.rs
+++ b/key-server/src/acl_storage.rs
@@ -19,10 +19,11 @@ use std::collections::{HashMap, HashSet};
 use parking_lot::{Mutex, RwLock};
 use ethereum_types::Address;
 use ethabi::FunctionOutputDecoder;
-use blockchain::{SecretStoreChain, NewBlocksNotify, ContractAddress, BlockId};
-use types::{Error, ServerKeyId};
+use log::trace;
+use crate::blockchain::{SecretStoreChain, NewBlocksNotify, ContractAddress, BlockId};
+use crate::types::{Error, ServerKeyId};
 
-use_contract!(acl_storage, "res/acl_storage.json");
+ethabi_contract::use_contract!(acl_storage, "res/acl_storage.json");
 
 const ACL_CHECKER_CONTRACT_REGISTRY_NAME: &'static str = "secretstore_acl_checker";
 

--- a/key-server/src/blockchain.rs
+++ b/key-server/src/blockchain.rs
@@ -15,10 +15,10 @@
 // along with Parity Secret Store.  If not, see <http://www.gnu.org/licenses/>.
 
 use std::sync::Arc;
-use bytes::Bytes;
+use parity_bytes::Bytes;
 use ethereum_types::{H256, Address, Public};
 use ethabi::RawLog;
-use crypto::publickey::{Signature, Error as EthKeyError};
+use parity_crypto::publickey::{Signature, Error as EthKeyError};
 
 /// Type for block number.
 /// Duplicated from ethcore types

--- a/key-server/src/key_server_cluster/admin_sessions/key_version_negotiation_session.rs
+++ b/key-server/src/key_server_cluster/admin_sessions/key_version_negotiation_session.rs
@@ -17,18 +17,19 @@
 use std::sync::Arc;
 use std::collections::{BTreeSet, BTreeMap};
 use ethereum_types::{Address, H256};
-use crypto::publickey::Secret;
+use log::warn;
+use parity_crypto::publickey::Secret;
 use futures::Oneshot;
 use parking_lot::Mutex;
-use key_server_cluster::{Error, SessionId, NodeId, DocumentKeyShare};
-use key_server_cluster::cluster::Cluster;
-use key_server_cluster::cluster_sessions::{SessionIdWithSubSession, ClusterSession, CompletionSignal};
-use key_server_cluster::decryption_session::SessionImpl as DecryptionSession;
-use key_server_cluster::signing_session_ecdsa::SessionImpl as EcdsaSigningSession;
-use key_server_cluster::signing_session_schnorr::SessionImpl as SchnorrSigningSession;
-use key_server_cluster::message::{Message, KeyVersionNegotiationMessage, RequestKeyVersions,
+use crate::key_server_cluster::{Error, SessionId, NodeId, DocumentKeyShare};
+use crate::key_server_cluster::cluster::Cluster;
+use crate::key_server_cluster::cluster_sessions::{SessionIdWithSubSession, ClusterSession, CompletionSignal};
+use crate::key_server_cluster::decryption_session::SessionImpl as DecryptionSession;
+use crate::key_server_cluster::signing_session_ecdsa::SessionImpl as EcdsaSigningSession;
+use crate::key_server_cluster::signing_session_schnorr::SessionImpl as SchnorrSigningSession;
+use crate::key_server_cluster::message::{Message, KeyVersionNegotiationMessage, RequestKeyVersions,
 	KeyVersions, KeyVersionsError, FailedKeyVersionContinueAction, CommonKeyData};
-use key_server_cluster::admin_sessions::ShareChangeSessionMeta;
+use crate::key_server_cluster::admin_sessions::ShareChangeSessionMeta;
 
 // TODO [Opt]: change sessions so that versions are sent by chunks.
 /// Number of versions sent in single message.
@@ -617,16 +618,16 @@ mod tests {
 	use std::sync::Arc;
 	use std::collections::{VecDeque, BTreeMap, BTreeSet};
 	use ethereum_types::{H512, H160, Address};
-	use crypto::publickey::public_to_address;
-	use key_server_cluster::{NodeId, SessionId, Error, KeyStorage, DummyKeyStorage,
+	use parity_crypto::publickey::public_to_address;
+	use crate::key_server_cluster::{NodeId, SessionId, Error, KeyStorage, DummyKeyStorage,
 		DocumentKeyShare, DocumentKeyShareVersion};
-	use key_server_cluster::math;
-	use key_server_cluster::cluster::Cluster;
-	use key_server_cluster::cluster::tests::DummyCluster;
-	use key_server_cluster::cluster_sessions::ClusterSession;
-	use key_server_cluster::admin_sessions::ShareChangeSessionMeta;
-	use key_server_cluster::decryption_session::create_default_decryption_session;
-	use key_server_cluster::message::{
+	use crate::key_server_cluster::math;
+	use crate::key_server_cluster::cluster::Cluster;
+	use crate::key_server_cluster::cluster::tests::DummyCluster;
+	use crate::key_server_cluster::cluster_sessions::ClusterSession;
+	use crate::key_server_cluster::admin_sessions::ShareChangeSessionMeta;
+	use crate::key_server_cluster::decryption_session::create_default_decryption_session;
+	use crate::key_server_cluster::message::{
 		Message, KeyVersionNegotiationMessage, RequestKeyVersions,
 		CommonKeyData, KeyVersions,
 	};

--- a/key-server/src/key_server_cluster/admin_sessions/mod.rs
+++ b/key-server/src/key_server_cluster/admin_sessions/mod.rs
@@ -21,7 +21,7 @@ pub mod share_change_session;
 
 mod sessions_queue;
 
-use key_server_cluster::{SessionId, NodeId, SessionMeta, Error};
+use crate::key_server_cluster::{SessionId, NodeId, SessionMeta, Error};
 
 /// Share change session metadata.
 #[derive(Debug, Clone)]

--- a/key-server/src/key_server_cluster/admin_sessions/servers_set_change_session.rs
+++ b/key-server/src/key_server_cluster/admin_sessions/servers_set_change_session.rs
@@ -17,31 +17,32 @@
 use std::sync::Arc;
 use std::collections::{BTreeSet, BTreeMap};
 use std::collections::btree_map::Entry;
+use log::warn;
 use futures::Oneshot;
 use parking_lot::Mutex;
 use ethereum_types::H256;
-use crypto::publickey::{Public, Signature};
-use key_server_cluster::{Error, NodeId, SessionId, KeyStorage};
-use key_server_cluster::math;
-use key_server_cluster::cluster::Cluster;
-use key_server_cluster::cluster_sessions::{ClusterSession, CompletionSignal};
-use key_server_cluster::message::{Message, ServersSetChangeMessage,
+use parity_crypto::publickey::{Public, Signature};
+use crate::key_server_cluster::{Error, NodeId, SessionId, KeyStorage};
+use crate::key_server_cluster::math;
+use crate::key_server_cluster::cluster::Cluster;
+use crate::key_server_cluster::cluster_sessions::{ClusterSession, CompletionSignal};
+use crate::key_server_cluster::message::{Message, ServersSetChangeMessage,
 	ConsensusMessageWithServersSet, InitializeConsensusSessionWithServersSet,
 	ServersSetChangeConsensusMessage, ConfirmConsensusInitialization, UnknownSessionsRequest, UnknownSessions,
 	ServersSetChangeShareAddMessage, ServersSetChangeError, ServersSetChangeCompleted,
 	ServersSetChangeDelegate, ServersSetChangeDelegateResponse, InitializeShareChangeSession,
 	ConfirmShareChangeSessionInitialization, KeyVersionNegotiationMessage, ShareChangeKeyVersionNegotiation};
-use key_server_cluster::share_change_session::{ShareChangeSession, ShareChangeSessionParams, ShareChangeSessionPlan,
+use crate::key_server_cluster::share_change_session::{ShareChangeSession, ShareChangeSessionParams, ShareChangeSessionPlan,
 	prepare_share_change_session_plan};
-use key_server_cluster::key_version_negotiation_session::{SessionImpl as KeyVersionNegotiationSessionImpl,
+use crate::key_server_cluster::key_version_negotiation_session::{SessionImpl as KeyVersionNegotiationSessionImpl,
 	SessionParams as KeyVersionNegotiationSessionParams, LargestSupportResultComputer,
 	SessionTransport as KeyVersionNegotiationTransport};
-use key_server_cluster::jobs::job_session::JobTransport;
-use key_server_cluster::jobs::servers_set_change_access_job::{ServersSetChangeAccessJob, ServersSetChangeAccessRequest};
-use key_server_cluster::jobs::unknown_sessions_job::{UnknownSessionsJob};
-use key_server_cluster::jobs::consensus_session::{ConsensusSessionParams, ConsensusSessionState, ConsensusSession};
-use key_server_cluster::admin_sessions::sessions_queue::SessionsQueue;
-use key_server_cluster::admin_sessions::ShareChangeSessionMeta;
+use crate::key_server_cluster::jobs::job_session::JobTransport;
+use crate::key_server_cluster::jobs::servers_set_change_access_job::{ServersSetChangeAccessJob, ServersSetChangeAccessRequest};
+use crate::key_server_cluster::jobs::unknown_sessions_job::{UnknownSessionsJob};
+use crate::key_server_cluster::jobs::consensus_session::{ConsensusSessionParams, ConsensusSessionState, ConsensusSession};
+use crate::key_server_cluster::admin_sessions::sessions_queue::SessionsQueue;
+use crate::key_server_cluster::admin_sessions::ShareChangeSessionMeta;
 
 /// Maximal number of active share change sessions.
 const MAX_ACTIVE_KEY_SESSIONS: usize = 64;
@@ -1050,16 +1051,16 @@ pub mod tests {
 	use std::sync::Arc;
 	use std::collections::{VecDeque, BTreeMap, BTreeSet};
 	use ethereum_types::H256;
-	use crypto::publickey::{Random, Generator, Public, Signature, KeyPair, sign};
-	use blockchain::SigningKeyPair;
-	use key_server_cluster::{NodeId, SessionId, Error, KeyStorage, PlainNodeKeyPair};
-	use key_server_cluster::cluster_sessions::ClusterSession;
-	use key_server_cluster::cluster::tests::MessageLoop as ClusterMessageLoop;
-	use key_server_cluster::generation_session::tests::{MessageLoop as GenerationMessageLoop};
-	use key_server_cluster::math;
-	use key_server_cluster::message::Message;
-	use key_server_cluster::admin_sessions::ShareChangeSessionMeta;
-	use key_server_cluster::jobs::servers_set_change_access_job::ordered_nodes_hash;
+	use parity_crypto::publickey::{Random, Generator, Public, Signature, KeyPair, sign};
+	use crate::blockchain::SigningKeyPair;
+	use crate::key_server_cluster::{NodeId, SessionId, Error, KeyStorage, PlainNodeKeyPair};
+	use crate::key_server_cluster::cluster_sessions::ClusterSession;
+	use crate::key_server_cluster::cluster::tests::MessageLoop as ClusterMessageLoop;
+	use crate::key_server_cluster::generation_session::tests::{MessageLoop as GenerationMessageLoop};
+	use crate::key_server_cluster::math;
+	use crate::key_server_cluster::message::Message;
+	use crate::key_server_cluster::admin_sessions::ShareChangeSessionMeta;
+	use crate::key_server_cluster::jobs::servers_set_change_access_job::ordered_nodes_hash;
 	use super::{SessionImpl, SessionParams};
 
 	pub trait AdminSessionAdapter<S> {

--- a/key-server/src/key_server_cluster/admin_sessions/sessions_queue.rs
+++ b/key-server/src/key_server_cluster/admin_sessions/sessions_queue.rs
@@ -16,7 +16,7 @@
 
 use std::sync::Arc;
 use std::collections::{VecDeque, BTreeSet};
-use key_server_cluster::{Error, SessionId, KeyStorage};
+use crate::key_server_cluster::{Error, SessionId, KeyStorage};
 
 /// Queue of share change sessions.
 pub struct SessionsQueue {

--- a/key-server/src/key_server_cluster/admin_sessions/share_add_session.rs
+++ b/key-server/src/key_server_cluster/admin_sessions/share_add_session.rs
@@ -17,21 +17,22 @@
 use std::sync::Arc;
 use std::collections::{BTreeSet, BTreeMap};
 use ethereum_types::{H256, Address};
-use crypto::publickey::{Public, Secret, Signature};
+use log::warn;
+use parity_crypto::publickey::{Public, Secret, Signature};
 use futures::Oneshot;
 use parking_lot::Mutex;
-use key_server_cluster::{Error, SessionId, NodeId, DocumentKeyShare, DocumentKeyShareVersion, KeyStorage};
-use key_server_cluster::cluster::Cluster;
-use key_server_cluster::cluster_sessions::{ClusterSession, CompletionSignal};
-use key_server_cluster::math;
-use key_server_cluster::message::{Message, ShareAddMessage, ShareAddConsensusMessage, ConsensusMessageOfShareAdd,
+use crate::key_server_cluster::{Error, SessionId, NodeId, DocumentKeyShare, DocumentKeyShareVersion, KeyStorage};
+use crate::key_server_cluster::cluster::Cluster;
+use crate::key_server_cluster::cluster_sessions::{ClusterSession, CompletionSignal};
+use crate::key_server_cluster::math;
+use crate::key_server_cluster::message::{Message, ShareAddMessage, ShareAddConsensusMessage, ConsensusMessageOfShareAdd,
 	InitializeConsensusSessionOfShareAdd, KeyShareCommon, NewKeysDissemination, ShareAddError,
 	ConfirmConsensusInitialization, CommonKeyData};
-use key_server_cluster::jobs::job_session::JobTransport;
-use key_server_cluster::jobs::dummy_job::{DummyJob, DummyJobTransport};
-use key_server_cluster::jobs::servers_set_change_access_job::{ServersSetChangeAccessJob, ServersSetChangeAccessRequest};
-use key_server_cluster::jobs::consensus_session::{ConsensusSessionParams, ConsensusSessionState, ConsensusSession};
-use key_server_cluster::admin_sessions::ShareChangeSessionMeta;
+use crate::key_server_cluster::jobs::job_session::JobTransport;
+use crate::key_server_cluster::jobs::dummy_job::{DummyJob, DummyJobTransport};
+use crate::key_server_cluster::jobs::servers_set_change_access_job::{ServersSetChangeAccessJob, ServersSetChangeAccessRequest};
+use crate::key_server_cluster::jobs::consensus_session::{ConsensusSessionParams, ConsensusSessionState, ConsensusSession};
+use crate::key_server_cluster::admin_sessions::ShareChangeSessionMeta;
 
 /// Share addition session transport.
 pub trait SessionTransport: Clone + JobTransport<PartialJobRequest=ServersSetChangeAccessRequest, PartialJobResponse=bool> {
@@ -888,12 +889,12 @@ impl SessionTransport for IsolatedSessionTransport {
 #[cfg(test)]
 pub mod tests {
 	use std::collections::BTreeSet;
-	use crypto::publickey::{Random, Generator, Public};
-	use blockchain::SigningKeyPair;
-	use key_server_cluster::{NodeId, Error, KeyStorage};
-	use key_server_cluster::cluster::tests::MessageLoop as ClusterMessageLoop;
-	use key_server_cluster::servers_set_change_session::tests::{MessageLoop, AdminSessionAdapter, generate_key};
-	use key_server_cluster::admin_sessions::ShareChangeSessionMeta;
+	use parity_crypto::publickey::{Random, Generator, Public};
+	use crate::blockchain::SigningKeyPair;
+	use crate::key_server_cluster::{NodeId, Error, KeyStorage};
+	use crate::key_server_cluster::cluster::tests::MessageLoop as ClusterMessageLoop;
+	use crate::key_server_cluster::servers_set_change_session::tests::{MessageLoop, AdminSessionAdapter, generate_key};
+	use crate::key_server_cluster::admin_sessions::ShareChangeSessionMeta;
 	use super::{SessionImpl, SessionParams, IsolatedSessionTransport};
 
 	struct Adapter;

--- a/key-server/src/key_server_cluster/admin_sessions/share_change_session.rs
+++ b/key-server/src/key_server_cluster/admin_sessions/share_change_session.rs
@@ -17,18 +17,19 @@
 use std::sync::Arc;
 use std::collections::{BTreeSet, BTreeMap};
 use ethereum_types::H256;
-use crypto::publickey::Secret;
-use key_server_cluster::{Error, NodeId, SessionId, ServerKeyId, KeyStorage};
-use key_server_cluster::cluster::Cluster;
-use key_server_cluster::cluster_sessions::ClusterSession;
-use key_server_cluster::math;
-use key_server_cluster::jobs::servers_set_change_access_job::ServersSetChangeAccessRequest;
-use key_server_cluster::jobs::job_session::JobTransport;
-use key_server_cluster::message::{Message, ServersSetChangeMessage, ServersSetChangeShareAddMessage};
-use key_server_cluster::share_add_session::{SessionTransport as ShareAddSessionTransport,
+use log::warn;
+use parity_crypto::publickey::Secret;
+use crate::key_server_cluster::{Error, NodeId, SessionId, ServerKeyId, KeyStorage};
+use crate::key_server_cluster::cluster::Cluster;
+use crate::key_server_cluster::cluster_sessions::ClusterSession;
+use crate::key_server_cluster::math;
+use crate::key_server_cluster::jobs::servers_set_change_access_job::ServersSetChangeAccessRequest;
+use crate::key_server_cluster::jobs::job_session::JobTransport;
+use crate::key_server_cluster::message::{Message, ServersSetChangeMessage, ServersSetChangeShareAddMessage};
+use crate::key_server_cluster::share_add_session::{SessionTransport as ShareAddSessionTransport,
 	SessionImpl as ShareAddSessionImpl, SessionParams as ShareAddSessionParams};
-use key_server_cluster::message::ShareAddMessage;
-use key_server_cluster::admin_sessions::ShareChangeSessionMeta;
+use crate::key_server_cluster::message::ShareAddMessage;
+use crate::key_server_cluster::admin_sessions::ShareChangeSessionMeta;
 
 /// Single session meta-change session. Brief overview:
 /// 1) nodes that have been already removed from cluster (isolated nodes) are removed from session
@@ -302,7 +303,7 @@ impl ShareChangeSessionPlan {
 
 #[cfg(test)]
 mod tests {
-	use key_server_cluster::math;
+	use crate::key_server_cluster::math;
 	use super::prepare_share_change_session_plan;
 
 	#[test]

--- a/key-server/src/key_server_cluster/client_sessions/decryption_session.rs
+++ b/key-server/src/key_server_cluster/client_sessions/decryption_session.rs
@@ -19,18 +19,19 @@ use std::sync::Arc;
 use futures::Oneshot;
 use parking_lot::Mutex;
 use ethereum_types::{Address, H256};
-use crypto::publickey::Secret;
-use key_server_cluster::{Error, AclStorage, DocumentKeyShare, NodeId, SessionId, Requester,
+use log::warn;
+use parity_crypto::publickey::Secret;
+use crate::key_server_cluster::{Error, AclStorage, DocumentKeyShare, NodeId, SessionId, Requester,
 	EncryptedDocumentKeyShadow, SessionMeta};
-use key_server_cluster::cluster::Cluster;
-use key_server_cluster::cluster_sessions::{SessionIdWithSubSession, ClusterSession, CompletionSignal};
-use key_server_cluster::message::{Message, DecryptionMessage, DecryptionConsensusMessage, RequestPartialDecryption,
+use crate::key_server_cluster::cluster::Cluster;
+use crate::key_server_cluster::cluster_sessions::{SessionIdWithSubSession, ClusterSession, CompletionSignal};
+use crate::key_server_cluster::message::{Message, DecryptionMessage, DecryptionConsensusMessage, RequestPartialDecryption,
 	PartialDecryption, DecryptionSessionError, DecryptionSessionCompleted, ConsensusMessage, InitializeConsensusSession,
 	ConfirmConsensusInitialization, DecryptionSessionDelegation, DecryptionSessionDelegationCompleted};
-use key_server_cluster::jobs::job_session::{JobSession, JobSessionState, JobTransport};
-use key_server_cluster::jobs::key_access_job::KeyAccessJob;
-use key_server_cluster::jobs::decryption_job::{PartialDecryptionRequest, PartialDecryptionResponse, DecryptionJob};
-use key_server_cluster::jobs::consensus_session::{ConsensusSessionParams, ConsensusSessionState, ConsensusSession};
+use crate::key_server_cluster::jobs::job_session::{JobSession, JobSessionState, JobTransport};
+use crate::key_server_cluster::jobs::key_access_job::KeyAccessJob;
+use crate::key_server_cluster::jobs::decryption_job::{PartialDecryptionRequest, PartialDecryptionResponse, DecryptionJob};
+use crate::key_server_cluster::jobs::consensus_session::{ConsensusSessionParams, ConsensusSessionState, ConsensusSession};
 
 /// Distributed decryption session.
 /// Based on "ECDKG: A Distributed Key Generation Protocol Based on Elliptic Curve Discrete Logarithm" paper:
@@ -820,8 +821,8 @@ impl JobTransport for DecryptionJobTransport {
 
 #[cfg(test)]
 pub fn create_default_decryption_session() -> Arc<SessionImpl> {
-	use acl_storage::DummyAclStorage;
-	use key_server_cluster::cluster::tests::DummyCluster;
+	use crate::acl_storage::DummyAclStorage;
+	use crate::key_server_cluster::cluster::tests::DummyCluster;
 	use ethereum_types::H512;
 
 	Arc::new(SessionImpl::new(SessionParams {
@@ -845,16 +846,16 @@ pub fn create_default_decryption_session() -> Arc<SessionImpl> {
 mod tests {
 	use std::sync::Arc;
 	use std::collections::{BTreeMap, VecDeque};
-	use acl_storage::DummyAclStorage;
-	use crypto::publickey::{KeyPair, Random, Generator, Public, Secret, public_to_address};
-	use key_server_cluster::{NodeId, DocumentKeyShare, DocumentKeyShareVersion, SessionId, Requester,
+	use crate::acl_storage::DummyAclStorage;
+	use parity_crypto::publickey::{KeyPair, Random, Generator, Public, Secret, public_to_address};
+	use crate::key_server_cluster::{NodeId, DocumentKeyShare, DocumentKeyShareVersion, SessionId, Requester,
 		Error, EncryptedDocumentKeyShadow, SessionMeta};
-	use key_server_cluster::cluster::tests::DummyCluster;
-	use key_server_cluster::cluster_sessions::ClusterSession;
-	use key_server_cluster::decryption_session::{SessionImpl, SessionParams};
-	use key_server_cluster::message::{self, Message, DecryptionMessage};
-	use key_server_cluster::math;
-	use key_server_cluster::jobs::consensus_session::ConsensusSessionState;
+	use crate::key_server_cluster::cluster::tests::DummyCluster;
+	use crate::key_server_cluster::cluster_sessions::ClusterSession;
+	use crate::key_server_cluster::decryption_session::{SessionImpl, SessionParams};
+	use crate::key_server_cluster::message::{self, Message, DecryptionMessage};
+	use crate::key_server_cluster::math;
+	use crate::key_server_cluster::jobs::consensus_session::ConsensusSessionState;
 	use ethereum_types::{H512, Address};
 	use std::str::FromStr;
 
@@ -906,7 +907,7 @@ mod tests {
 			cluster
 		}).collect();
 		let requester = Random.generate();
-		let signature = Some(crypto::publickey::sign(requester.secret(), &session_id).unwrap());
+		let signature = Some(parity_crypto::publickey::sign(requester.secret(), &session_id).unwrap());
 		let sessions: Vec<_> = (0..5).map(|i| SessionImpl::new(SessionParams {
 			meta: SessionMeta {
 				id: session_id,
@@ -973,7 +974,7 @@ mod tests {
 		let self_node_id = Random.generate().public().clone();
 		nodes.insert(self_node_id, Random.generate().secret().clone());
 		let msg = [1u8; 32].into();
-		let requester = Some(Requester::Signature(crypto::publickey::sign(Random.generate().secret(), &msg).unwrap()));
+		let requester = Some(Requester::Signature(parity_crypto::publickey::sign(Random.generate().secret(), &msg).unwrap()));
 		let params = SessionParams {
 			meta: SessionMeta {
 				id: SessionId::from([1u8; 32]),
@@ -1024,7 +1025,7 @@ mod tests {
 			cluster: Arc::new(DummyCluster::new(self_node_id.clone())),
 			nonce: 0,
 		}, Some(Requester::Signature(
-			crypto::publickey::sign(Random.generate().secret(), &SessionId::from(DUMMY_SESSION_ID)).unwrap()
+			parity_crypto::publickey::sign(Random.generate().secret(), &SessionId::from(DUMMY_SESSION_ID)).unwrap()
 		))).unwrap().0;
 		assert_eq!(session.initialize(Default::default(), Default::default(), false, false), Err(Error::InvalidMessage));
 	}
@@ -1061,7 +1062,7 @@ mod tests {
 			cluster: Arc::new(DummyCluster::new(self_node_id.clone())),
 			nonce: 0,
 		}, Some(Requester::Signature(
-			crypto::publickey::sign(Random.generate().secret(), &SessionId::from(DUMMY_SESSION_ID)).unwrap()
+			parity_crypto::publickey::sign(Random.generate().secret(), &SessionId::from(DUMMY_SESSION_ID)).unwrap()
 		))).unwrap().0;
 		assert_eq!(session.initialize(Default::default(), Default::default(), false, false), Err(Error::ConsensusUnreachable));
 	}
@@ -1083,7 +1084,7 @@ mod tests {
 				session_nonce: 0,
 				origin: None,
 				message: message::ConsensusMessage::InitializeConsensusSession(message::InitializeConsensusSession {
-					requester: Requester::Signature(crypto::publickey::sign(
+					requester: Requester::Signature(parity_crypto::publickey::sign(
 						Random.generate().secret(), &SessionId::from(DUMMY_SESSION_ID)).unwrap()).into(),
 					version: Default::default(),
 				}),
@@ -1099,7 +1100,7 @@ mod tests {
 				session_nonce: 0,
 				origin: None,
 				message: message::ConsensusMessage::InitializeConsensusSession(message::InitializeConsensusSession {
-					requester: Requester::Signature(crypto::publickey::sign(Random.generate().secret(),
+					requester: Requester::Signature(parity_crypto::publickey::sign(Random.generate().secret(),
 						&SessionId::from(DUMMY_SESSION_ID)).unwrap()).into(),
 					version: Default::default(),
 				}),
@@ -1124,7 +1125,7 @@ mod tests {
 				session_nonce: 0,
 				origin: None,
 				message: message::ConsensusMessage::InitializeConsensusSession(message::InitializeConsensusSession {
-					requester: Requester::Signature(crypto::publickey::sign(Random.generate().secret(),
+					requester: Requester::Signature(parity_crypto::publickey::sign(Random.generate().secret(),
 						&SessionId::from(DUMMY_SESSION_ID)).unwrap()).into(),
 					version: Default::default(),
 				}),
@@ -1316,8 +1317,8 @@ mod tests {
 		assert!(decrypted_secret.common_point.is_some());
 		assert!(decrypted_secret.decrypt_shadows.is_some());
 		// check that KS client is able to restore original secret
-		use crypto::DEFAULT_MAC;
-		use crypto::publickey::ecies::decrypt;
+		use parity_crypto::DEFAULT_MAC;
+		use parity_crypto::publickey::ecies::decrypt;
 		let decrypt_shadows: Vec<_> = decrypted_secret.decrypt_shadows.unwrap().into_iter()
 			.map(|c| Secret::copy_from_slice(&decrypt(key_pair.secret(), &DEFAULT_MAC, &c).unwrap()).unwrap())
 			.collect();
@@ -1461,8 +1462,8 @@ mod tests {
 		assert_eq!(1, sessions.iter().skip(1).filter(|s| s.broadcast_shadows().is_none()).count());
 
 		// 4 nodes must be able to recover original secret
-		use crypto::DEFAULT_MAC;
-		use crypto::publickey::ecies::decrypt;
+		use parity_crypto::DEFAULT_MAC;
+		use parity_crypto::publickey::ecies::decrypt;
 		let result = sessions[0].decrypted_secret().unwrap().unwrap();
 		assert_eq!(3, sessions.iter().skip(1).filter(|s| s.decrypted_secret() == Some(Ok(result.clone()))).count());
 		let decrypt_shadows: Vec<_> = result.decrypt_shadows.unwrap().into_iter()

--- a/key-server/src/key_server_cluster/client_sessions/encryption_session.rs
+++ b/key-server/src/key_server_cluster/client_sessions/encryption_session.rs
@@ -18,14 +18,15 @@ use std::collections::BTreeMap;
 use std::fmt::{Debug, Formatter, Error as FmtError};
 use std::sync::Arc;
 use futures::Oneshot;
+use log::warn;
 use parking_lot::Mutex;
 use ethereum_types::Address;
-use crypto::publickey::Public;
-use key_server_cluster::{Error, NodeId, SessionId, Requester, KeyStorage,
+use parity_crypto::publickey::Public;
+use crate::key_server_cluster::{Error, NodeId, SessionId, Requester, KeyStorage,
 	DocumentKeyShare, ServerKeyId};
-use key_server_cluster::cluster::Cluster;
-use key_server_cluster::cluster_sessions::{ClusterSession, CompletionSignal};
-use key_server_cluster::message::{Message, EncryptionMessage, InitializeEncryptionSession,
+use crate::key_server_cluster::cluster::Cluster;
+use crate::key_server_cluster::cluster_sessions::{ClusterSession, CompletionSignal};
+use crate::key_server_cluster::message::{Message, EncryptionMessage, InitializeEncryptionSession,
 	ConfirmEncryptionInitialization, EncryptionSessionError};
 
 /// Encryption (distributed key generation) session.

--- a/key-server/src/key_server_cluster/client_sessions/generation_session.rs
+++ b/key-server/src/key_server_cluster/client_sessions/generation_session.rs
@@ -20,12 +20,13 @@ use std::sync::Arc;
 use futures::Oneshot;
 use parking_lot::Mutex;
 use ethereum_types::Address;
-use crypto::publickey::{Public, Secret};
-use key_server_cluster::{Error, NodeId, SessionId, KeyStorage, DocumentKeyShare, DocumentKeyShareVersion};
-use key_server_cluster::math;
-use key_server_cluster::cluster::Cluster;
-use key_server_cluster::cluster_sessions::{ClusterSession, CompletionSignal};
-use key_server_cluster::message::{Message, GenerationMessage, InitializeSession, ConfirmInitialization, CompleteInitialization,
+use log::warn;
+use parity_crypto::publickey::{Public, Secret};
+use crate::key_server_cluster::{Error, NodeId, SessionId, KeyStorage, DocumentKeyShare, DocumentKeyShareVersion};
+use crate::key_server_cluster::math;
+use crate::key_server_cluster::cluster::Cluster;
+use crate::key_server_cluster::cluster_sessions::{ClusterSession, CompletionSignal};
+use crate::key_server_cluster::message::{Message, GenerationMessage, InitializeSession, ConfirmInitialization, CompleteInitialization,
 	KeysDissemination, PublicKeyShare, SessionError, SessionCompleted};
 
 /// Distributed key generation session.
@@ -951,16 +952,15 @@ fn check_threshold(threshold: usize, nodes: &BTreeSet<NodeId>) -> Result<(), Err
 pub mod tests {
 	use std::sync::Arc;
 	use ethereum_types::H256;
-	use crypto::publickey::{Random, Generator, KeyPair, Secret};
-	use key_server_cluster::{NodeId, Error, KeyStorage, SessionId};
-	use key_server_cluster::message::{self, Message, GenerationMessage, KeysDissemination,
+	use parity_crypto::publickey::{Random, Generator, KeyPair, Secret};
+	use crate::key_server_cluster::{NodeId, Error, KeyStorage, SessionId, ServerKeyId};
+	use crate::key_server_cluster::message::{self, Message, GenerationMessage, KeysDissemination,
 		PublicKeyShare, ConfirmInitialization};
-	use key_server_cluster::cluster::tests::{MessageLoop as ClusterMessageLoop, make_clusters_and_preserve_sessions};
-	use key_server_cluster::cluster_sessions::ClusterSession;
-	use key_server_cluster::generation_session::{SessionImpl, SessionState};
-	use key_server_cluster::math;
-	use key_server_cluster::math::tests::do_encryption_and_decryption;
-	use ServerKeyId;
+	use crate::key_server_cluster::cluster::tests::{MessageLoop as ClusterMessageLoop, make_clusters_and_preserve_sessions};
+	use crate::key_server_cluster::cluster_sessions::ClusterSession;
+	use crate::key_server_cluster::generation_session::{SessionImpl, SessionState};
+	use crate::key_server_cluster::math;
+	use crate::key_server_cluster::math::tests::do_encryption_and_decryption;
 
 	#[derive(Debug)]
 	pub struct MessageLoop(pub ClusterMessageLoop);

--- a/key-server/src/key_server_cluster/client_sessions/signing_session_schnorr.rs
+++ b/key-server/src/key_server_cluster/client_sessions/signing_session_schnorr.rs
@@ -18,21 +18,22 @@ use std::collections::BTreeSet;
 use std::sync::Arc;
 use futures::Oneshot;
 use parking_lot::Mutex;
-use crypto::publickey::{Public, Secret};
+use parity_crypto::publickey::{Public, Secret};
 use ethereum_types::H256;
-use key_server_cluster::{Error, NodeId, SessionId, Requester, SessionMeta, AclStorage, DocumentKeyShare};
-use key_server_cluster::cluster::{Cluster};
-use key_server_cluster::cluster_sessions::{SessionIdWithSubSession, ClusterSession, CompletionSignal};
-use key_server_cluster::generation_session::{SessionImpl as GenerationSession, SessionParams as GenerationSessionParams,
+use log::warn;
+use crate::key_server_cluster::{Error, NodeId, SessionId, Requester, SessionMeta, AclStorage, DocumentKeyShare};
+use crate::key_server_cluster::cluster::{Cluster};
+use crate::key_server_cluster::cluster_sessions::{SessionIdWithSubSession, ClusterSession, CompletionSignal};
+use crate::key_server_cluster::generation_session::{SessionImpl as GenerationSession, SessionParams as GenerationSessionParams,
 	SessionState as GenerationSessionState};
-use key_server_cluster::message::{Message, SchnorrSigningMessage, SchnorrSigningConsensusMessage, SchnorrSigningGenerationMessage,
+use crate::key_server_cluster::message::{Message, SchnorrSigningMessage, SchnorrSigningConsensusMessage, SchnorrSigningGenerationMessage,
 	SchnorrRequestPartialSignature, SchnorrPartialSignature, SchnorrSigningSessionCompleted, GenerationMessage,
 	ConsensusMessage, SchnorrSigningSessionError, InitializeConsensusSession, ConfirmConsensusInitialization,
 	SchnorrSigningSessionDelegation, SchnorrSigningSessionDelegationCompleted};
-use key_server_cluster::jobs::job_session::JobTransport;
-use key_server_cluster::jobs::key_access_job::KeyAccessJob;
-use key_server_cluster::jobs::signing_job_schnorr::{SchnorrPartialSigningRequest, SchnorrPartialSigningResponse, SchnorrSigningJob};
-use key_server_cluster::jobs::consensus_session::{ConsensusSessionParams, ConsensusSessionState, ConsensusSession};
+use crate::key_server_cluster::jobs::job_session::JobTransport;
+use crate::key_server_cluster::jobs::key_access_job::KeyAccessJob;
+use crate::key_server_cluster::jobs::signing_job_schnorr::{SchnorrPartialSigningRequest, SchnorrPartialSigningResponse, SchnorrSigningJob};
+use crate::key_server_cluster::jobs::consensus_session::{ConsensusSessionParams, ConsensusSessionState, ConsensusSession};
 
 /// Distributed Schnorr-signing session.
 /// Based on "Efficient Multi-Party Digital Signature using Adaptive Secret Sharing for Low-Power Devices in Wireless Network" paper.
@@ -819,16 +820,16 @@ mod tests {
 	use std::str::FromStr;
 	use std::collections::BTreeMap;
 	use ethereum_types::{Address, H256};
-	use crypto::publickey::{Random, Generator, Public, Secret, public_to_address};
-	use acl_storage::DummyAclStorage;
-	use key_server_cluster::{SessionId, Requester, SessionMeta, Error, KeyStorage};
-	use key_server_cluster::cluster::tests::MessageLoop as ClusterMessageLoop;
-	use key_server_cluster::generation_session::tests::MessageLoop as GenerationMessageLoop;
-	use key_server_cluster::math;
-	use key_server_cluster::message::{SchnorrSigningMessage, SchnorrSigningConsensusMessage,
+	use parity_crypto::publickey::{Random, Generator, Public, Secret, public_to_address};
+	use crate::acl_storage::DummyAclStorage;
+	use crate::key_server_cluster::{SessionId, Requester, SessionMeta, Error, KeyStorage};
+	use crate::key_server_cluster::cluster::tests::MessageLoop as ClusterMessageLoop;
+	use crate::key_server_cluster::generation_session::tests::MessageLoop as GenerationMessageLoop;
+	use crate::key_server_cluster::math;
+	use crate::key_server_cluster::message::{SchnorrSigningMessage, SchnorrSigningConsensusMessage,
 		ConsensusMessage, ConfirmConsensusInitialization, SchnorrSigningGenerationMessage, GenerationMessage,
 		ConfirmInitialization, InitializeSession, SchnorrRequestPartialSignature};
-	use key_server_cluster::signing_session_schnorr::{SessionImpl, SessionState, SessionParams};
+	use crate::key_server_cluster::signing_session_schnorr::{SessionImpl, SessionState, SessionParams};
 
 	#[derive(Debug)]
 	pub struct MessageLoop(pub ClusterMessageLoop);
@@ -843,7 +844,7 @@ mod tests {
 
 		pub fn into_session(&self, at_node: usize) -> SessionImpl {
 			let requester = Some(Requester::Signature(
-				crypto::publickey::sign(Random.generate().secret(), &SessionId::from([1u8; 32])).unwrap())
+				parity_crypto::publickey::sign(Random.generate().secret(), &SessionId::from([1u8; 32])).unwrap())
 			);
 			let dummy_doc = [1u8; 32].into();
 			SessionImpl::new(SessionParams {
@@ -866,7 +867,7 @@ mod tests {
 		pub fn init_with_version(self, key_version: Option<H256>) -> Result<(Self, Public, H256), Error> {
 			let message_hash = H256::random();
 			let requester = Random.generate();
-			let signature = crypto::publickey::sign(requester.secret(), &SessionId::from([1u8; 32])).unwrap();
+			let signature = parity_crypto::publickey::sign(requester.secret(), &SessionId::from([1u8; 32])).unwrap();
 			self.0.cluster(0).client().new_schnorr_signing_session(
 				SessionId::from([1u8; 32]),
 				signature.into(),

--- a/key-server/src/key_server_cluster/cluster.rs
+++ b/key-server/src/key_server_cluster/cluster.rs
@@ -17,33 +17,34 @@
 use std::sync::Arc;
 use std::collections::{BTreeMap, BTreeSet};
 use parking_lot::RwLock;
-use crypto::publickey::{Public, Signature, Random, Generator};
+use parity_crypto::publickey::{Public, Signature, Random, Generator};
 use ethereum_types::{Address, H256};
 use parity_runtime::Executor;
-use blockchain::SigningKeyPair;
-use key_server_cluster::{Error, NodeId, SessionId, Requester, AclStorage, KeyStorage, KeyServerSet};
-use key_server_cluster::cluster_sessions::{WaitableSession, ClusterSession, AdminSession, ClusterSessions,
+use log::trace;
+use crate::blockchain::SigningKeyPair;
+use crate::key_server_cluster::{Error, NodeId, SessionId, Requester, AclStorage, KeyStorage, KeyServerSet};
+use crate::key_server_cluster::cluster_sessions::{WaitableSession, ClusterSession, AdminSession, ClusterSessions,
 	SessionIdWithSubSession, ClusterSessionsContainer, SERVERS_SET_CHANGE_SESSION_ID, create_cluster_view,
 	AdminSessionCreationData, ClusterSessionsListener};
-use key_server_cluster::cluster_sessions_creator::ClusterSessionCreator;
-use key_server_cluster::cluster_connections::{ConnectionProvider, ConnectionManager};
-use key_server_cluster::cluster_connections_net::{NetConnectionsManager,
+use crate::key_server_cluster::cluster_sessions_creator::ClusterSessionCreator;
+use crate::key_server_cluster::cluster_connections::{ConnectionProvider, ConnectionManager};
+use crate::key_server_cluster::cluster_connections_net::{NetConnectionsManager,
 	NetConnectionsContainer, NetConnectionsManagerConfig};
-use key_server_cluster::cluster_message_processor::{MessageProcessor, SessionsMessageProcessor};
-use key_server_cluster::message::Message;
-use key_server_cluster::generation_session::{SessionImpl as GenerationSession};
-use key_server_cluster::decryption_session::{SessionImpl as DecryptionSession};
-use key_server_cluster::encryption_session::{SessionImpl as EncryptionSession};
-use key_server_cluster::signing_session_ecdsa::{SessionImpl as EcdsaSigningSession};
-use key_server_cluster::signing_session_schnorr::{SessionImpl as SchnorrSigningSession};
-use key_server_cluster::key_version_negotiation_session::{SessionImpl as KeyVersionNegotiationSession,
+use crate::key_server_cluster::cluster_message_processor::{MessageProcessor, SessionsMessageProcessor};
+use crate::key_server_cluster::message::Message;
+use crate::key_server_cluster::generation_session::{SessionImpl as GenerationSession};
+use crate::key_server_cluster::decryption_session::{SessionImpl as DecryptionSession};
+use crate::key_server_cluster::encryption_session::{SessionImpl as EncryptionSession};
+use crate::key_server_cluster::signing_session_ecdsa::{SessionImpl as EcdsaSigningSession};
+use crate::key_server_cluster::signing_session_schnorr::{SessionImpl as SchnorrSigningSession};
+use crate::key_server_cluster::key_version_negotiation_session::{SessionImpl as KeyVersionNegotiationSession,
 	IsolatedSessionTransport as KeyVersionNegotiationSessionTransport, ContinueAction};
-use key_server_cluster::connection_trigger::{ConnectionTrigger,
+use crate::key_server_cluster::connection_trigger::{ConnectionTrigger,
 	SimpleConnectionTrigger, ServersSetChangeSessionCreatorConnector};
-use key_server_cluster::connection_trigger_with_migration::ConnectionTriggerWithMigration;
+use crate::key_server_cluster::connection_trigger_with_migration::ConnectionTriggerWithMigration;
 
 #[cfg(test)]
-use key_server_cluster::cluster_connections::tests::{MessagesQueue, TestConnections, new_test_connections};
+use crate::key_server_cluster::cluster_connections::tests::{MessagesQueue, TestConnections, new_test_connections};
 
 /// Cluster interface for external clients.
 pub trait ClusterClient: Send + Sync {
@@ -656,23 +657,23 @@ pub mod tests {
 	use futures::Future;
 	use parking_lot::{Mutex, RwLock};
 	use ethereum_types::{Address, H256};
-	use crypto::publickey::{Random, Generator, Public, Signature, sign};
-	use blockchain::SigningKeyPair;
-	use key_server_cluster::{NodeId, SessionId, Requester, Error, DummyAclStorage, DummyKeyStorage,
+	use parity_crypto::publickey::{Random, Generator, Public, Signature, sign};
+	use crate::blockchain::SigningKeyPair;
+	use crate::key_server_cluster::{NodeId, SessionId, Requester, Error, DummyAclStorage, DummyKeyStorage,
 		MapKeyServerSet, PlainNodeKeyPair};
-	use key_server_cluster::message::Message;
-	use key_server_cluster::cluster::{new_test_cluster, Cluster, ClusterCore, ClusterConfiguration, ClusterClient};
-	use key_server_cluster::cluster_connections::ConnectionManager;
-	use key_server_cluster::cluster_connections::tests::{MessagesQueue, TestConnections};
-	use key_server_cluster::cluster_sessions::{WaitableSession, ClusterSession, ClusterSessions, AdminSession,
+	use crate::key_server_cluster::message::Message;
+	use crate::key_server_cluster::cluster::{new_test_cluster, Cluster, ClusterCore, ClusterConfiguration, ClusterClient};
+	use crate::key_server_cluster::cluster_connections::ConnectionManager;
+	use crate::key_server_cluster::cluster_connections::tests::{MessagesQueue, TestConnections};
+	use crate::key_server_cluster::cluster_sessions::{WaitableSession, ClusterSession, ClusterSessions, AdminSession,
 		ClusterSessionsListener};
-	use key_server_cluster::generation_session::{SessionImpl as GenerationSession,
+	use crate::key_server_cluster::generation_session::{SessionImpl as GenerationSession,
 		SessionState as GenerationSessionState};
-	use key_server_cluster::decryption_session::{SessionImpl as DecryptionSession};
-	use key_server_cluster::encryption_session::{SessionImpl as EncryptionSession};
-	use key_server_cluster::signing_session_ecdsa::{SessionImpl as EcdsaSigningSession};
-	use key_server_cluster::signing_session_schnorr::{SessionImpl as SchnorrSigningSession};
-	use key_server_cluster::key_version_negotiation_session::{SessionImpl as KeyVersionNegotiationSession,
+	use crate::key_server_cluster::decryption_session::{SessionImpl as DecryptionSession};
+	use crate::key_server_cluster::encryption_session::{SessionImpl as EncryptionSession};
+	use crate::key_server_cluster::signing_session_ecdsa::{SessionImpl as EcdsaSigningSession};
+	use crate::key_server_cluster::signing_session_schnorr::{SessionImpl as SchnorrSigningSession};
+	use crate::key_server_cluster::key_version_negotiation_session::{SessionImpl as KeyVersionNegotiationSession,
 		IsolatedSessionTransport as KeyVersionNegotiationSessionTransport};
 
 	#[derive(Default)]

--- a/key-server/src/key_server_cluster/cluster_connections.rs
+++ b/key-server/src/key_server_cluster/cluster_connections.rs
@@ -16,8 +16,8 @@
 
 use std::collections::BTreeSet;
 use std::sync::Arc;
-use key_server_cluster::{Error, NodeId};
-use key_server_cluster::message::Message;
+use crate::key_server_cluster::{Error, NodeId};
+use crate::key_server_cluster::message::Message;
 
 /// Connection to the single node. Provides basic information about connected node and
 /// allows sending messages to this node.
@@ -64,8 +64,8 @@ pub mod tests {
 	use std::sync::Arc;
 	use std::sync::atomic::{AtomicBool, Ordering};
 	use parking_lot::Mutex;
-	use key_server_cluster::{Error, NodeId};
-	use key_server_cluster::message::Message;
+	use crate::key_server_cluster::{Error, NodeId};
+	use crate::key_server_cluster::message::Message;
 	use super::{ConnectionManager, Connection, ConnectionProvider};
 
 	/// Shared messages queue.

--- a/key-server/src/key_server_cluster/cluster_connections_net.rs
+++ b/key-server/src/key_server_cluster/cluster_connections_net.rs
@@ -21,21 +21,22 @@ use std::net::{SocketAddr, IpAddr};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use futures::{future, Future, Stream};
+use log::{error, trace, warn};
 use parking_lot::{Mutex, RwLock};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::timer::{Interval, timeout::Error as TimeoutError};
 use tokio_io::IoFuture;
-use crypto::publickey::KeyPair;
+use parity_crypto::publickey::KeyPair;
 use parity_runtime::Executor;
-use blockchain::SigningKeyPair;
-use key_server_cluster::{Error, NodeId, ClusterConfiguration};
-use key_server_cluster::cluster_connections::{ConnectionProvider, Connection, ConnectionManager};
-use key_server_cluster::connection_trigger::{Maintain, ConnectionTrigger};
-use key_server_cluster::cluster_message_processor::MessageProcessor;
-use key_server_cluster::io::{DeadlineStatus, ReadMessage, SharedTcpStream,
+use crate::blockchain::SigningKeyPair;
+use crate::key_server_cluster::{Error, NodeId, ClusterConfiguration};
+use crate::key_server_cluster::cluster_connections::{ConnectionProvider, Connection, ConnectionManager};
+use crate::key_server_cluster::connection_trigger::{Maintain, ConnectionTrigger};
+use crate::key_server_cluster::cluster_message_processor::MessageProcessor;
+use crate::key_server_cluster::io::{DeadlineStatus, ReadMessage, SharedTcpStream,
 	read_encrypted_message, WriteMessage, write_encrypted_message};
-use key_server_cluster::message::{self, ClusterMessage, Message};
-use key_server_cluster::net::{accept_connection as io_accept_connection,
+use crate::key_server_cluster::message::{self, ClusterMessage, Message};
+use crate::key_server_cluster::net::{accept_connection as io_accept_connection,
 	connect as io_connect, Connection as IoConnection};
 
 /// Empty future.

--- a/key-server/src/key_server_cluster/cluster_message_processor.rs
+++ b/key-server/src/key_server_cluster/cluster_message_processor.rs
@@ -15,18 +15,19 @@
 // along with Parity Secret Store.  If not, see <http://www.gnu.org/licenses/>.
 
 use std::sync::Arc;
-use blockchain::SigningKeyPair;
-use key_server_cluster::{Error, NodeId};
-use key_server_cluster::cluster::{ServersSetChangeParams, new_servers_set_change_session};
-use key_server_cluster::cluster_sessions::{AdminSession};
-use key_server_cluster::cluster_connections::{ConnectionProvider, Connection};
-use key_server_cluster::cluster_sessions::{ClusterSession, ClusterSessions, ClusterSessionsContainer,
+use log::{info, trace, warn};
+use crate::blockchain::SigningKeyPair;
+use crate::key_server_cluster::{Error, NodeId};
+use crate::key_server_cluster::cluster::{ServersSetChangeParams, new_servers_set_change_session};
+use crate::key_server_cluster::cluster_sessions::{AdminSession};
+use crate::key_server_cluster::cluster_connections::{ConnectionProvider, Connection};
+use crate::key_server_cluster::cluster_sessions::{ClusterSession, ClusterSessions, ClusterSessionsContainer,
 	create_cluster_view};
-use key_server_cluster::cluster_sessions_creator::{ClusterSessionCreator, IntoSessionId};
-use key_server_cluster::message::{self, Message, ClusterMessage};
-use key_server_cluster::key_version_negotiation_session::{SessionImpl as KeyVersionNegotiationSession,
+use crate::key_server_cluster::cluster_sessions_creator::{ClusterSessionCreator, IntoSessionId};
+use crate::key_server_cluster::message::{self, Message, ClusterMessage};
+use crate::key_server_cluster::key_version_negotiation_session::{SessionImpl as KeyVersionNegotiationSession,
 	IsolatedSessionTransport as KeyVersionNegotiationSessionTransport, ContinueAction};
-use key_server_cluster::connection_trigger::ServersSetChangeSessionCreatorConnector;
+use crate::key_server_cluster::connection_trigger::ServersSetChangeSessionCreatorConnector;
 
 /// Something that is able to process signals/messages from other nodes.
 pub trait MessageProcessor: Send + Sync {

--- a/key-server/src/key_server_cluster/cluster_sessions.rs
+++ b/key-server/src/key_server_cluster/cluster_sessions.rs
@@ -19,26 +19,27 @@ use std::sync::{Arc, Weak};
 use std::sync::atomic::AtomicBool;
 use std::collections::{VecDeque, BTreeMap, BTreeSet};
 use futures::{oneshot, Oneshot, Complete, Future};
+use lazy_static::lazy_static;
 use parking_lot::{Mutex, RwLock, Condvar};
 use ethereum_types::H256;
-use crypto::publickey::Secret;
-use blockchain::SigningKeyPair;
-use key_server_cluster::{Error, NodeId, SessionId};
-use key_server_cluster::cluster::{Cluster, ClusterConfiguration, ClusterView};
-use key_server_cluster::cluster_connections::ConnectionProvider;
-use key_server_cluster::connection_trigger::ServersSetChangeSessionCreatorConnector;
-use key_server_cluster::message::{self, Message};
-use key_server_cluster::generation_session::{SessionImpl as GenerationSessionImpl};
-use key_server_cluster::decryption_session::{SessionImpl as DecryptionSessionImpl};
-use key_server_cluster::encryption_session::{SessionImpl as EncryptionSessionImpl};
-use key_server_cluster::signing_session_ecdsa::{SessionImpl as EcdsaSigningSessionImpl};
-use key_server_cluster::signing_session_schnorr::{SessionImpl as SchnorrSigningSessionImpl};
-use key_server_cluster::share_add_session::{SessionImpl as ShareAddSessionImpl, IsolatedSessionTransport as ShareAddTransport};
-use key_server_cluster::servers_set_change_session::{SessionImpl as ServersSetChangeSessionImpl};
-use key_server_cluster::key_version_negotiation_session::{SessionImpl as KeyVersionNegotiationSessionImpl,
+use parity_crypto::publickey::Secret;
+use crate::blockchain::SigningKeyPair;
+use crate::key_server_cluster::{Error, NodeId, SessionId};
+use crate::key_server_cluster::cluster::{Cluster, ClusterConfiguration, ClusterView};
+use crate::key_server_cluster::cluster_connections::ConnectionProvider;
+use crate::key_server_cluster::connection_trigger::ServersSetChangeSessionCreatorConnector;
+use crate::key_server_cluster::message::{self, Message};
+use crate::key_server_cluster::generation_session::{SessionImpl as GenerationSessionImpl};
+use crate::key_server_cluster::decryption_session::{SessionImpl as DecryptionSessionImpl};
+use crate::key_server_cluster::encryption_session::{SessionImpl as EncryptionSessionImpl};
+use crate::key_server_cluster::signing_session_ecdsa::{SessionImpl as EcdsaSigningSessionImpl};
+use crate::key_server_cluster::signing_session_schnorr::{SessionImpl as SchnorrSigningSessionImpl};
+use crate::key_server_cluster::share_add_session::{SessionImpl as ShareAddSessionImpl, IsolatedSessionTransport as ShareAddTransport};
+use crate::key_server_cluster::servers_set_change_session::{SessionImpl as ServersSetChangeSessionImpl};
+use crate::key_server_cluster::key_version_negotiation_session::{SessionImpl as KeyVersionNegotiationSessionImpl,
 	IsolatedSessionTransport as VersionNegotiationTransport};
 
-use key_server_cluster::cluster_sessions_creator::{GenerationSessionCreator, EncryptionSessionCreator, DecryptionSessionCreator,
+use crate::key_server_cluster::cluster_sessions_creator::{GenerationSessionCreator, EncryptionSessionCreator, DecryptionSessionCreator,
 	SchnorrSigningSessionCreator, KeyVersionNegotiationSessionCreator, AdminSessionCreator, SessionCreatorCore,
 	EcdsaSigningSessionCreator, ClusterSessionCreator};
 
@@ -669,12 +670,12 @@ pub fn create_cluster_view(self_key_pair: Arc<dyn SigningKeyPair>, connections: 
 mod tests {
 	use std::sync::Arc;
 	use std::sync::atomic::{AtomicUsize, Ordering};
-	use crypto::publickey::{Random, Generator};
-	use key_server_cluster::{Error, DummyAclStorage, DummyKeyStorage, MapKeyServerSet, PlainNodeKeyPair};
-	use key_server_cluster::cluster::ClusterConfiguration;
-	use key_server_cluster::connection_trigger::SimpleServersSetChangeSessionCreatorConnector;
-	use key_server_cluster::cluster::tests::DummyCluster;
-	use key_server_cluster::generation_session::{SessionImpl as GenerationSession};
+	use parity_crypto::publickey::{Random, Generator};
+	use crate::key_server_cluster::{Error, DummyAclStorage, DummyKeyStorage, MapKeyServerSet, PlainNodeKeyPair};
+	use crate::key_server_cluster::cluster::ClusterConfiguration;
+	use crate::key_server_cluster::connection_trigger::SimpleServersSetChangeSessionCreatorConnector;
+	use crate::key_server_cluster::cluster::tests::DummyCluster;
+	use crate::key_server_cluster::generation_session::{SessionImpl as GenerationSession};
 	use super::{ClusterSessions, AdminSessionCreationData, ClusterSessionsListener,
 		ClusterSessionsContainerState, SESSION_TIMEOUT_INTERVAL};
 

--- a/key-server/src/key_server_cluster/cluster_sessions_creator.rs
+++ b/key-server/src/key_server_cluster/cluster_sessions_creator.rs
@@ -18,30 +18,30 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::collections::BTreeMap;
 use parking_lot::RwLock;
-use crypto::publickey::Public;
-use key_server_cluster::{Error, NodeId, SessionId, Requester, AclStorage, KeyStorage, DocumentKeyShare, SessionMeta};
-use key_server_cluster::cluster::{Cluster, ClusterConfiguration};
-use key_server_cluster::connection_trigger::ServersSetChangeSessionCreatorConnector;
-use key_server_cluster::cluster_sessions::{WaitableSession, ClusterSession, SessionIdWithSubSession,
+use parity_crypto::publickey::Public;
+use crate::key_server_cluster::{Error, NodeId, SessionId, Requester, AclStorage, KeyStorage, DocumentKeyShare, SessionMeta};
+use crate::key_server_cluster::cluster::{Cluster, ClusterConfiguration};
+use crate::key_server_cluster::connection_trigger::ServersSetChangeSessionCreatorConnector;
+use crate::key_server_cluster::cluster_sessions::{WaitableSession, ClusterSession, SessionIdWithSubSession,
 	AdminSession, AdminSessionCreationData};
-use key_server_cluster::message::{self, Message, DecryptionMessage, SchnorrSigningMessage, ConsensusMessageOfShareAdd,
+use crate::key_server_cluster::message::{self, Message, DecryptionMessage, SchnorrSigningMessage, ConsensusMessageOfShareAdd,
 	ShareAddMessage, ServersSetChangeMessage, ConsensusMessage, ConsensusMessageWithServersSet, EcdsaSigningMessage};
-use key_server_cluster::generation_session::{SessionImpl as GenerationSessionImpl, SessionParams as GenerationSessionParams};
-use key_server_cluster::decryption_session::{SessionImpl as DecryptionSessionImpl,
+use crate::key_server_cluster::generation_session::{SessionImpl as GenerationSessionImpl, SessionParams as GenerationSessionParams};
+use crate::key_server_cluster::decryption_session::{SessionImpl as DecryptionSessionImpl,
 	SessionParams as DecryptionSessionParams};
-use key_server_cluster::encryption_session::{SessionImpl as EncryptionSessionImpl, SessionParams as EncryptionSessionParams};
-use key_server_cluster::signing_session_ecdsa::{SessionImpl as EcdsaSigningSessionImpl,
+use crate::key_server_cluster::encryption_session::{SessionImpl as EncryptionSessionImpl, SessionParams as EncryptionSessionParams};
+use crate::key_server_cluster::signing_session_ecdsa::{SessionImpl as EcdsaSigningSessionImpl,
 	SessionParams as EcdsaSigningSessionParams};
-use key_server_cluster::signing_session_schnorr::{SessionImpl as SchnorrSigningSessionImpl,
+use crate::key_server_cluster::signing_session_schnorr::{SessionImpl as SchnorrSigningSessionImpl,
 	SessionParams as SchnorrSigningSessionParams};
-use key_server_cluster::share_add_session::{SessionImpl as ShareAddSessionImpl,
+use crate::key_server_cluster::share_add_session::{SessionImpl as ShareAddSessionImpl,
 	SessionParams as ShareAddSessionParams, IsolatedSessionTransport as ShareAddTransport};
-use key_server_cluster::servers_set_change_session::{SessionImpl as ServersSetChangeSessionImpl,
+use crate::key_server_cluster::servers_set_change_session::{SessionImpl as ServersSetChangeSessionImpl,
 	SessionParams as ServersSetChangeSessionParams};
-use key_server_cluster::key_version_negotiation_session::{SessionImpl as KeyVersionNegotiationSessionImpl,
+use crate::key_server_cluster::key_version_negotiation_session::{SessionImpl as KeyVersionNegotiationSessionImpl,
 	SessionParams as KeyVersionNegotiationSessionParams, IsolatedSessionTransport as VersionNegotiationTransport,
 	FastestResultComputer as FastestResultKeyVersionsResultComputer};
-use key_server_cluster::admin_sessions::ShareChangeSessionMeta;
+use crate::key_server_cluster::admin_sessions::ShareChangeSessionMeta;
 
 /// Generic cluster session creator.
 pub trait ClusterSessionCreator<S: ClusterSession> {

--- a/key-server/src/key_server_cluster/connection_trigger.rs
+++ b/key-server/src/key_server_cluster/connection_trigger.rs
@@ -18,15 +18,16 @@ use std::collections::{BTreeSet, BTreeMap};
 use std::collections::btree_map::Entry;
 use std::net::SocketAddr;
 use std::sync::Arc;
+use log::trace;
 use ethereum_types::H256;
-use crypto::publickey::Public;
-use key_server_cluster::{KeyServerSet, KeyServerSetSnapshot};
-use key_server_cluster::cluster::{ClusterConfiguration, ServersSetChangeParams};
-use key_server_cluster::cluster_sessions::AdminSession;
-use key_server_cluster::cluster_connections::{Connection};
-use key_server_cluster::cluster_connections_net::{NetConnectionsContainer};
-use types::{Error, NodeId};
-use blockchain::SigningKeyPair;
+use parity_crypto::publickey::Public;
+use crate::key_server_cluster::{KeyServerSet, KeyServerSetSnapshot};
+use crate::key_server_cluster::cluster::{ClusterConfiguration, ServersSetChangeParams};
+use crate::key_server_cluster::cluster_sessions::AdminSession;
+use crate::key_server_cluster::cluster_connections::{Connection};
+use crate::key_server_cluster::cluster_connections_net::{NetConnectionsContainer};
+use crate::types::{Error, NodeId};
+use crate::blockchain::SigningKeyPair;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 /// Describes which maintain() call is required.
@@ -215,9 +216,9 @@ fn select_nodes_to_disconnect(current_set: &BTreeMap<NodeId, SocketAddr>, new_se
 mod tests {
 	use std::collections::BTreeSet;
 	use std::sync::Arc;
-	use crypto::publickey::{Random, Generator};
-	use key_server_cluster::{MapKeyServerSet, PlainNodeKeyPair, KeyServerSetSnapshot, KeyServerSetMigration};
-	use key_server_cluster::cluster_connections_net::NetConnectionsContainer;
+	use parity_crypto::publickey::{Random, Generator};
+	use crate::key_server_cluster::{MapKeyServerSet, PlainNodeKeyPair, KeyServerSetSnapshot, KeyServerSetMigration};
+	use crate::key_server_cluster::cluster_connections_net::NetConnectionsContainer;
 	use super::{Maintain, TriggerConnections, ConnectionsAction, ConnectionTrigger, SimpleConnectionTrigger,
 		select_nodes_to_disconnect, adjust_connections};
 

--- a/key-server/src/key_server_cluster/connection_trigger_with_migration.rs
+++ b/key-server/src/key_server_cluster/connection_trigger_with_migration.rs
@@ -18,17 +18,18 @@ use std::collections::{BTreeSet, BTreeMap};
 use std::net::SocketAddr;
 use std::sync::Arc;
 use ethereum_types::H256;
-use crypto::publickey::Public;
+use log::{trace, warn};
+use parity_crypto::publickey::Public;
 use parking_lot::Mutex;
-use key_server_cluster::{KeyServerSet, KeyServerSetSnapshot, KeyServerSetMigration, is_migration_required};
-use key_server_cluster::cluster::{ClusterConfiguration, ServersSetChangeParams};
-use key_server_cluster::cluster_connections_net::NetConnectionsContainer;
-use key_server_cluster::cluster_sessions::{AdminSession, ClusterSession};
-use key_server_cluster::jobs::servers_set_change_access_job::ordered_nodes_hash;
-use key_server_cluster::connection_trigger::{Maintain, ConnectionsAction, ConnectionTrigger,
+use crate::key_server_cluster::{KeyServerSet, KeyServerSetSnapshot, KeyServerSetMigration, is_migration_required};
+use crate::key_server_cluster::cluster::{ClusterConfiguration, ServersSetChangeParams};
+use crate::key_server_cluster::cluster_connections_net::NetConnectionsContainer;
+use crate::key_server_cluster::cluster_sessions::{AdminSession, ClusterSession};
+use crate::key_server_cluster::jobs::servers_set_change_access_job::ordered_nodes_hash;
+use crate::key_server_cluster::connection_trigger::{Maintain, ConnectionsAction, ConnectionTrigger,
 	ServersSetChangeSessionCreatorConnector, TriggerConnections};
-use types::{Error, NodeId};
-use blockchain::SigningKeyPair;
+use crate::types::{Error, NodeId};
+use crate::blockchain::SigningKeyPair;
 
 /// Key servers set change trigger with automated migration procedure.
 pub struct ConnectionTriggerWithMigration {
@@ -449,8 +450,8 @@ fn select_master_node(snapshot: &KeyServerSetSnapshot) -> &NodeId {
 
 #[cfg(test)]
 mod tests {
-	use key_server_cluster::{KeyServerSetSnapshot, KeyServerSetMigration};
-	use key_server_cluster::connection_trigger::ConnectionsAction;
+	use crate::key_server_cluster::{KeyServerSetSnapshot, KeyServerSetMigration};
+	use crate::key_server_cluster::connection_trigger::ConnectionsAction;
 	use super::{MigrationState, SessionState, SessionAction, migration_state, maintain_session,
 		maintain_connections, select_master_node};
 	use ethereum_types::{H256, H512};

--- a/key-server/src/key_server_cluster/io/handshake.rs
+++ b/key-server/src/key_server_cluster/io/handshake.rs
@@ -35,15 +35,15 @@
 use std::io;
 use std::sync::Arc;
 use std::collections::BTreeSet;
-use futures::{Future, Poll, Async};
+use futures::{try_ready, Future, Poll, Async};
 use tokio_io::{AsyncRead, AsyncWrite};
-use crypto::publickey::ecdh::agree;
-use crypto::publickey::{Random, Generator, KeyPair, Public, Signature, verify_public, sign, recover};
+use parity_crypto::publickey::ecdh::agree;
+use parity_crypto::publickey::{Random, Generator, KeyPair, Public, Signature, verify_public, sign, recover};
 use ethereum_types::H256;
-use blockchain::SigningKeyPair;
-use key_server_cluster::{NodeId, Error};
-use key_server_cluster::message::{Message, ClusterMessage, NodePublicKey, NodePrivateKeySignature};
-use key_server_cluster::io::{write_message, write_encrypted_message, WriteMessage, ReadMessage,
+use crate::blockchain::SigningKeyPair;
+use crate::key_server_cluster::{NodeId, Error};
+use crate::key_server_cluster::message::{Message, ClusterMessage, NodePublicKey, NodePrivateKeySignature};
+use crate::key_server_cluster::io::{write_message, write_encrypted_message, WriteMessage, ReadMessage,
 	read_message, read_encrypted_message, fix_shared_key};
 
 /// Start handshake procedure with another node from the cluster.
@@ -314,11 +314,11 @@ mod tests {
 	use std::sync::Arc;
 	use std::collections::BTreeSet;
 	use futures::Future;
-	use crypto::publickey::{Random, Generator, sign};
+	use parity_crypto::publickey::{Random, Generator, sign};
 	use ethereum_types::H256;
-	use key_server_cluster::PlainNodeKeyPair;
-	use key_server_cluster::io::message::tests::TestIo;
-	use key_server_cluster::message::{Message, ClusterMessage, NodePublicKey, NodePrivateKeySignature};
+	use crate::key_server_cluster::PlainNodeKeyPair;
+	use crate::key_server_cluster::io::message::tests::TestIo;
+	use crate::key_server_cluster::message::{Message, ClusterMessage, NodePublicKey, NodePrivateKeySignature};
 	use super::{handshake_with_init_data, accept_handshake, HandshakeResult};
 
 	fn prepare_test_io() -> (H256, TestIo) {

--- a/key-server/src/key_server_cluster/io/message.rs
+++ b/key-server/src/key_server_cluster/io/message.rs
@@ -19,12 +19,12 @@ use std::u16;
 use std::ops::Deref;
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use serde_json;
-use crypto::publickey::ecies;
-use crypto::publickey::{Secret, KeyPair};
-use crypto::publickey::ec_math_utils::CURVE_ORDER;
+use parity_crypto::publickey::ecies;
+use parity_crypto::publickey::{Secret, KeyPair};
+use parity_crypto::publickey::ec_math_utils::CURVE_ORDER;
 use ethereum_types::{H256, U256, BigEndianHash};
-use key_server_cluster::Error;
-use key_server_cluster::message::{Message, ClusterMessage, GenerationMessage, EncryptionMessage, DecryptionMessage,
+use crate::key_server_cluster::Error;
+use crate::key_server_cluster::message::{Message, ClusterMessage, GenerationMessage, EncryptionMessage, DecryptionMessage,
 	SchnorrSigningMessage, EcdsaSigningMessage, ServersSetChangeMessage, ShareAddMessage, KeyVersionNegotiationMessage};
 
 /// Size of serialized header.
@@ -305,10 +305,10 @@ pub mod tests {
 	use std::io;
 	use futures::Poll;
 	use tokio_io::{AsyncRead, AsyncWrite};
-	use crypto::publickey::{Random, Generator, KeyPair};
-	use crypto::publickey::ecdh::agree;
-	use key_server_cluster::Error;
-	use key_server_cluster::message::Message;
+	use parity_crypto::publickey::{Random, Generator, KeyPair};
+	use parity_crypto::publickey::ecdh::agree;
+	use crate::key_server_cluster::Error;
+	use crate::key_server_cluster::message::Message;
 	use super::{MESSAGE_HEADER_SIZE, CURRENT_HEADER_VERSION, MessageHeader, fix_shared_key, encrypt_message,
 		serialize_message, serialize_header, deserialize_header};
 

--- a/key-server/src/key_server_cluster/io/read_header.rs
+++ b/key-server/src/key_server_cluster/io/read_header.rs
@@ -15,11 +15,11 @@
 // along with Parity Secret Store.  If not, see <http://www.gnu.org/licenses/>.
 
 use std::io;
-use futures::{Future, Poll, Async};
+use futures::{try_ready, Future, Poll, Async};
 use tokio_io::AsyncRead;
 use tokio_io::io::{ReadExact, read_exact};
-use key_server_cluster::Error;
-use key_server_cluster::io::message::{MESSAGE_HEADER_SIZE, MessageHeader, deserialize_header};
+use crate::key_server_cluster::Error;
+use crate::key_server_cluster::io::message::{MESSAGE_HEADER_SIZE, MessageHeader, deserialize_header};
 
 /// Create future for read single message header from the stream.
 pub fn read_header<A>(a: A) -> ReadHeader<A> where A: AsyncRead {

--- a/key-server/src/key_server_cluster/io/read_message.rs
+++ b/key-server/src/key_server_cluster/io/read_message.rs
@@ -15,12 +15,12 @@
 // along with Parity Secret Store.  If not, see <http://www.gnu.org/licenses/>.
 
 use std::io;
-use futures::{Poll, Future, Async};
+use futures::{try_ready, Poll, Future, Async};
 use tokio_io::AsyncRead;
-use crypto::publickey::KeyPair;
-use key_server_cluster::Error;
-use key_server_cluster::message::Message;
-use key_server_cluster::io::{read_header, ReadHeader, read_payload, read_encrypted_payload, ReadPayload};
+use parity_crypto::publickey::KeyPair;
+use crate::key_server_cluster::Error;
+use crate::key_server_cluster::message::Message;
+use crate::key_server_cluster::io::{read_header, ReadHeader, read_payload, read_encrypted_payload, ReadPayload};
 
 /// Create future for read single message from the stream.
 pub fn read_message<A>(a: A) -> ReadMessage<A> where A: AsyncRead {

--- a/key-server/src/key_server_cluster/io/read_payload.rs
+++ b/key-server/src/key_server_cluster/io/read_payload.rs
@@ -15,13 +15,13 @@
 // along with Parity Secret Store.  If not, see <http://www.gnu.org/licenses/>.
 
 use std::io;
-use futures::{Poll, Future};
+use futures::{try_ready, Poll, Future};
 use tokio_io::AsyncRead;
 use tokio_io::io::{read_exact, ReadExact};
-use crypto::publickey::KeyPair;
-use key_server_cluster::Error;
-use key_server_cluster::message::Message;
-use key_server_cluster::io::message::{MessageHeader, deserialize_message, decrypt_message};
+use parity_crypto::publickey::KeyPair;
+use crate::key_server_cluster::Error;
+use crate::key_server_cluster::message::Message;
+use crate::key_server_cluster::io::message::{MessageHeader, deserialize_message, decrypt_message};
 
 /// Create future for read single message payload from the stream.
 pub fn read_payload<A>(a: A, header: MessageHeader) -> ReadPayload<A> where A: AsyncRead {

--- a/key-server/src/key_server_cluster/io/write_message.rs
+++ b/key-server/src/key_server_cluster/io/write_message.rs
@@ -18,9 +18,9 @@ use std::io;
 use futures::{Future, Poll};
 use tokio_io::AsyncWrite;
 use tokio_io::io::{WriteAll, write_all};
-use crypto::publickey::KeyPair;
-use key_server_cluster::message::Message;
-use key_server_cluster::io::{serialize_message, encrypt_message};
+use parity_crypto::publickey::KeyPair;
+use crate::key_server_cluster::message::Message;
+use crate::key_server_cluster::io::{serialize_message, encrypt_message};
 
 /// Write plain message to the channel.
 pub fn write_message<A>(a: A, message: Message) -> WriteMessage<A> where A: AsyncWrite {

--- a/key-server/src/key_server_cluster/jobs/consensus_session.rs
+++ b/key-server/src/key_server_cluster/jobs/consensus_session.rs
@@ -15,9 +15,9 @@
 // along with Parity Secret Store.  If not, see <http://www.gnu.org/licenses/>.
 
 use std::collections::BTreeSet;
-use key_server_cluster::{Error, NodeId, SessionMeta, Requester};
-use key_server_cluster::message::ConsensusMessage;
-use key_server_cluster::jobs::job_session::{JobSession, JobSessionState, JobTransport, JobExecutor, JobPartialRequestAction};
+use crate::key_server_cluster::{Error, NodeId, SessionMeta, Requester};
+use crate::key_server_cluster::message::ConsensusMessage;
+use crate::key_server_cluster::jobs::job_session::{JobSession, JobSessionState, JobTransport, JobExecutor, JobPartialRequestAction};
 
 /// Consensus session state.
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -367,11 +367,11 @@ impl<ConsensusExecutor, ConsensusTransport, ComputationExecutor, ComputationTran
 #[cfg(test)]
 mod tests {
 	use std::sync::Arc;
-	use crypto::publickey::{KeyPair, Random, Generator, sign, public_to_address};
-	use key_server_cluster::{Error, NodeId, SessionId, Requester, DummyAclStorage};
-	use key_server_cluster::message::{ConsensusMessage, InitializeConsensusSession, ConfirmConsensusInitialization};
-	use key_server_cluster::jobs::job_session::tests::{make_master_session_meta, make_slave_session_meta, SquaredSumJobExecutor, DummyJobTransport};
-	use key_server_cluster::jobs::key_access_job::KeyAccessJob;
+	use parity_crypto::publickey::{KeyPair, Random, Generator, sign, public_to_address};
+	use crate::key_server_cluster::{Error, NodeId, SessionId, Requester, DummyAclStorage};
+	use crate::key_server_cluster::message::{ConsensusMessage, InitializeConsensusSession, ConfirmConsensusInitialization};
+	use crate::key_server_cluster::jobs::job_session::tests::{make_master_session_meta, make_slave_session_meta, SquaredSumJobExecutor, DummyJobTransport};
+	use crate::key_server_cluster::jobs::key_access_job::KeyAccessJob;
 	use super::{ConsensusSession, ConsensusSessionParams, ConsensusSessionState};
 
 	type SquaredSumConsensusSession = ConsensusSession<KeyAccessJob, DummyJobTransport<Requester, bool>, SquaredSumJobExecutor, DummyJobTransport<u32, u32>>;

--- a/key-server/src/key_server_cluster/jobs/decryption_job.rs
+++ b/key-server/src/key_server_cluster/jobs/decryption_job.rs
@@ -16,12 +16,12 @@
 
 use std::collections::{BTreeSet, BTreeMap};
 use ethereum_types::H256;
-use crypto::publickey::{Public, Secret};
-use crypto::DEFAULT_MAC;
-use crypto::publickey::ecies::encrypt;
-use key_server_cluster::{Error, NodeId, DocumentKeyShare, EncryptedDocumentKeyShadow};
-use key_server_cluster::math;
-use key_server_cluster::jobs::job_session::{JobPartialRequestAction, JobPartialResponseAction, JobExecutor};
+use parity_crypto::publickey::{Public, Secret};
+use parity_crypto::DEFAULT_MAC;
+use parity_crypto::publickey::ecies::encrypt;
+use crate::key_server_cluster::{Error, NodeId, DocumentKeyShare, EncryptedDocumentKeyShadow};
+use crate::key_server_cluster::math;
+use crate::key_server_cluster::jobs::job_session::{JobPartialRequestAction, JobPartialResponseAction, JobExecutor};
 
 /// Decryption job.
 pub struct DecryptionJob {

--- a/key-server/src/key_server_cluster/jobs/dummy_job.rs
+++ b/key-server/src/key_server_cluster/jobs/dummy_job.rs
@@ -15,8 +15,8 @@
 // along with Parity Secret Store.  If not, see <http://www.gnu.org/licenses/>.
 
 use std::collections::{BTreeMap, BTreeSet};
-use key_server_cluster::{Error, NodeId};
-use key_server_cluster::jobs::job_session::{JobExecutor, JobTransport, JobPartialRequestAction, JobPartialResponseAction};
+use crate::key_server_cluster::{Error, NodeId};
+use crate::key_server_cluster::jobs::job_session::{JobExecutor, JobTransport, JobPartialRequestAction, JobPartialResponseAction};
 
 /// No-work job to use in generics (TODO [Refac]: create separate ShareChangeConsensusSession && remove this)
 pub struct DummyJob;

--- a/key-server/src/key_server_cluster/jobs/job_session.rs
+++ b/key-server/src/key_server_cluster/jobs/job_session.rs
@@ -15,7 +15,7 @@
 // along with Parity Secret Store.  If not, see <http://www.gnu.org/licenses/>.
 
 use std::collections::{BTreeSet, BTreeMap};
-use key_server_cluster::{Error, NodeId, SessionMeta};
+use crate::key_server_cluster::{Error, NodeId, SessionMeta};
 
 /// Partial response action.
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -392,8 +392,8 @@ fn consensus_unreachable(rejects: &BTreeMap<NodeId, bool>) -> Error {
 pub mod tests {
 	use std::collections::{VecDeque, BTreeMap, BTreeSet};
 	use parking_lot::Mutex;
-	use crypto::publickey::Public;
-	use key_server_cluster::{Error, NodeId, SessionId, SessionMeta};
+	use parity_crypto::publickey::Public;
+	use crate::key_server_cluster::{Error, NodeId, SessionId, SessionMeta};
 	use super::{JobPartialResponseAction, JobPartialRequestAction, JobExecutor, JobTransport, JobSession, JobSessionState};
 
 	pub struct SquaredSumJobExecutor;

--- a/key-server/src/key_server_cluster/jobs/key_access_job.rs
+++ b/key-server/src/key_server_cluster/jobs/key_access_job.rs
@@ -16,8 +16,8 @@
 
 use std::sync::Arc;
 use std::collections::{BTreeSet, BTreeMap};
-use key_server_cluster::{Error, NodeId, SessionId, Requester, AclStorage};
-use key_server_cluster::jobs::job_session::{JobPartialResponseAction, JobPartialRequestAction, JobExecutor};
+use crate::key_server_cluster::{Error, NodeId, SessionId, Requester, AclStorage};
+use crate::key_server_cluster::jobs::job_session::{JobPartialResponseAction, JobPartialRequestAction, JobExecutor};
 
 /// Purpose of this job is to construct set of nodes, which have agreed to provide access to the given key for the given requestor.
 pub struct KeyAccessJob {

--- a/key-server/src/key_server_cluster/jobs/servers_set_change_access_job.rs
+++ b/key-server/src/key_server_cluster/jobs/servers_set_change_access_job.rs
@@ -15,11 +15,11 @@
 // along with Parity Secret Store.  If not, see <http://www.gnu.org/licenses/>.
 
 use std::collections::{BTreeSet, BTreeMap};
-use crypto::publickey::{Public, Signature, recover};
+use parity_crypto::publickey::{Public, Signature, recover};
 use tiny_keccak::Keccak;
-use key_server_cluster::{Error, NodeId, SessionId};
-use key_server_cluster::message::{InitializeConsensusSessionWithServersSet, InitializeConsensusSessionOfShareAdd};
-use key_server_cluster::jobs::job_session::{JobPartialResponseAction, JobPartialRequestAction, JobExecutor};
+use crate::key_server_cluster::{Error, NodeId, SessionId};
+use crate::key_server_cluster::message::{InitializeConsensusSessionWithServersSet, InitializeConsensusSessionOfShareAdd};
+use crate::key_server_cluster::jobs::job_session::{JobPartialResponseAction, JobPartialRequestAction, JobExecutor};
 
 /// Purpose of this job is to check if requestor is administrator of SecretStore (i.e. it have access to change key servers set).
 pub struct ServersSetChangeAccessJob {

--- a/key-server/src/key_server_cluster/jobs/signing_job_ecdsa.rs
+++ b/key-server/src/key_server_cluster/jobs/signing_job_ecdsa.rs
@@ -15,11 +15,11 @@
 // along with Parity Secret Store.  If not, see <http://www.gnu.org/licenses/>.
 
 use std::collections::{BTreeSet, BTreeMap};
-use crypto::publickey::{Public, Secret, Signature};
+use parity_crypto::publickey::{Public, Secret, Signature};
 use ethereum_types::H256;
-use key_server_cluster::{Error, NodeId, DocumentKeyShare};
-use key_server_cluster::math;
-use key_server_cluster::jobs::job_session::{JobPartialRequestAction, JobPartialResponseAction, JobExecutor};
+use crate::key_server_cluster::{Error, NodeId, DocumentKeyShare};
+use crate::key_server_cluster::math;
+use crate::key_server_cluster::jobs::job_session::{JobPartialRequestAction, JobPartialResponseAction, JobExecutor};
 
 /// Signing job.
 pub struct EcdsaSigningJob {

--- a/key-server/src/key_server_cluster/jobs/signing_job_schnorr.rs
+++ b/key-server/src/key_server_cluster/jobs/signing_job_schnorr.rs
@@ -15,11 +15,11 @@
 // along with Parity Secret Store.  If not, see <http://www.gnu.org/licenses/>.
 
 use std::collections::{BTreeSet, BTreeMap};
-use crypto::publickey::{Public, Secret};
+use parity_crypto::publickey::{Public, Secret};
 use ethereum_types::H256;
-use key_server_cluster::{Error, NodeId, DocumentKeyShare};
-use key_server_cluster::math;
-use key_server_cluster::jobs::job_session::{JobPartialRequestAction, JobPartialResponseAction, JobExecutor};
+use crate::key_server_cluster::{Error, NodeId, DocumentKeyShare};
+use crate::key_server_cluster::math;
+use crate::key_server_cluster::jobs::job_session::{JobPartialRequestAction, JobPartialResponseAction, JobExecutor};
 
 /// Signing job.
 pub struct SchnorrSigningJob {

--- a/key-server/src/key_server_cluster/jobs/unknown_sessions_job.rs
+++ b/key-server/src/key_server_cluster/jobs/unknown_sessions_job.rs
@@ -16,8 +16,8 @@
 
 use std::sync::Arc;
 use std::collections::{BTreeSet, BTreeMap};
-use key_server_cluster::{Error, NodeId, SessionId, KeyStorage};
-use key_server_cluster::jobs::job_session::{JobPartialRequestAction, JobPartialResponseAction, JobExecutor};
+use crate::key_server_cluster::{Error, NodeId, SessionId, KeyStorage};
+use crate::key_server_cluster::jobs::job_session::{JobPartialRequestAction, JobPartialResponseAction, JobExecutor};
 
 /// Unknown sessions report job.
 pub struct UnknownSessionsJob {

--- a/key-server/src/key_server_cluster/math.rs
+++ b/key-server/src/key_server_cluster/math.rs
@@ -14,10 +14,10 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity Secret Store.  If not, see <http://www.gnu.org/licenses/>.
 
-use crypto::publickey::{Public, Secret, Signature, Random, Generator, ec_math_utils};
+use parity_crypto::publickey::{Public, Secret, Signature, Random, Generator, ec_math_utils};
 use ethereum_types::{H256, U256, BigEndianHash};
-use hash::keccak;
-use key_server_cluster::Error;
+use keccak_hash::keccak;
+use crate::key_server_cluster::Error;
 
 /// Encryption result.
 #[derive(Debug)]
@@ -539,7 +539,7 @@ pub fn compute_ecdsa_inversed_secret_coeff_from_shares(t: usize, id_numbers: &[S
 #[cfg(test)]
 pub mod tests {
 	use std::iter::once;
-	use crypto::publickey::{KeyPair, Secret, recover, verify_public};
+	use parity_crypto::publickey::{KeyPair, Secret, recover, verify_public};
 	use super::*;
 
 	#[derive(Clone)]

--- a/key-server/src/key_server_cluster/message.rs
+++ b/key-server/src/key_server_cluster/message.rs
@@ -16,8 +16,9 @@
 
 use std::fmt;
 use std::collections::{BTreeSet, BTreeMap};
-use crypto::publickey::Secret;
-use key_server_cluster::SessionId;
+use parity_crypto::publickey::Secret;
+use serde::{Serialize, Deserialize};
+use crate::key_server_cluster::SessionId;
 use super::{Error, SerializableH256, SerializablePublic, SerializableSecret,
 	SerializableSignature, SerializableMessageHash, SerializableRequester, SerializableAddress};
 

--- a/key-server/src/key_server_cluster/net/accept_connection.rs
+++ b/key-server/src/key_server_cluster/net/accept_connection.rs
@@ -18,12 +18,12 @@ use std::io;
 use std::sync::Arc;
 use std::net::SocketAddr;
 use std::time::Duration;
-use futures::{Future, Poll};
+use futures::{try_ready, Future, Poll};
 use tokio::net::TcpStream;
-use blockchain::SigningKeyPair;
-use key_server_cluster::Error;
-use key_server_cluster::io::{accept_handshake, Handshake, Deadline, deadline};
-use key_server_cluster::net::Connection;
+use crate::blockchain::SigningKeyPair;
+use crate::key_server_cluster::Error;
+use crate::key_server_cluster::io::{accept_handshake, Handshake, Deadline, deadline};
+use crate::key_server_cluster::net::Connection;
 
 /// Create future for accepting incoming connection.
 pub fn accept_connection(stream: TcpStream, self_key_pair: Arc<dyn SigningKeyPair>) -> Deadline<AcceptConnection> {

--- a/key-server/src/key_server_cluster/net/connect.rs
+++ b/key-server/src/key_server_cluster/net/connect.rs
@@ -19,12 +19,12 @@ use std::collections::BTreeSet;
 use std::io;
 use std::time::Duration;
 use std::net::SocketAddr;
-use futures::{Future, Poll, Async};
+use futures::{try_ready, Future, Poll, Async};
 use tokio::net::{TcpStream, tcp::ConnectFuture};
-use blockchain::SigningKeyPair;
-use key_server_cluster::{Error, NodeId};
-use key_server_cluster::io::{handshake, Handshake, Deadline, deadline};
-use key_server_cluster::net::Connection;
+use crate::blockchain::SigningKeyPair;
+use crate::key_server_cluster::{Error, NodeId};
+use crate::key_server_cluster::io::{handshake, Handshake, Deadline, deadline};
+use crate::key_server_cluster::net::Connection;
 
 /// Create future for connecting to other node.
 pub fn connect(address: &SocketAddr, self_key_pair: Arc<dyn SigningKeyPair>, trusted_nodes: BTreeSet<NodeId>) -> Deadline<Connect> {

--- a/key-server/src/key_server_cluster/net/connection.rs
+++ b/key-server/src/key_server_cluster/net/connection.rs
@@ -15,9 +15,9 @@
 // along with Parity Secret Store.  If not, see <http://www.gnu.org/licenses/>.
 
 use std::net;
-use crypto::publickey::KeyPair;
-use key_server_cluster::NodeId;
-use key_server_cluster::io::SharedTcpStream;
+use parity_crypto::publickey::KeyPair;
+use crate::key_server_cluster::NodeId;
+use crate::key_server_cluster::io::SharedTcpStream;
 
 /// Established connection data
 pub struct Connection {

--- a/key-server/src/key_server_set.rs
+++ b/key-server/src/key_server_set.rs
@@ -20,12 +20,13 @@ use std::collections::{BTreeMap, HashSet};
 use parking_lot::Mutex;
 use ethabi::FunctionOutputDecoder;
 use ethereum_types::{H256, Address};
-use crypto::publickey::public_to_address;
-use bytes::Bytes;
-use types::{Error, Public, NodeAddress, NodeId};
-use blockchain::{SecretStoreChain, NewBlocksNotify, SigningKeyPair, ContractAddress, BlockId};
+use log::{trace, warn};
+use parity_crypto::publickey::public_to_address;
+use parity_bytes::Bytes;
+use crate::types::{Error, Public, NodeAddress, NodeId};
+use crate::blockchain::{SecretStoreChain, NewBlocksNotify, SigningKeyPair, ContractAddress, BlockId};
 
-use_contract!(key_server, "res/key_server_set.json");
+ethabi_contract::use_contract!(key_server, "res/key_server_set.json");
 
 /// Name of KeyServerSet contract in registry.
 const KEY_SERVER_SET_CONTRACT_REGISTRY_NAME: &'static str = "secretstore_server_set";
@@ -574,7 +575,7 @@ pub mod tests {
 	use std::collections::BTreeMap;
 	use std::net::SocketAddr;
 	use ethereum_types::{H256, H512};
-	use crypto::publickey::Public;
+	use parity_crypto::publickey::Public;
 	use super::{update_future_set, update_number_of_confirmations, FutureNewSet,
 		KeyServerSet, KeyServerSetSnapshot, MIGRATION_CONFIRMATIONS_REQUIRED};
 

--- a/key-server/src/key_storage.rs
+++ b/key-server/src/key_storage.rs
@@ -19,10 +19,11 @@ use std::sync::Arc;
 use serde_json;
 use tiny_keccak::Keccak;
 use ethereum_types::{H256, Address};
-use crypto::publickey::{Secret, Public};
+use parity_crypto::publickey::{Secret, Public};
+use serde::{Serialize, Deserialize};
 use kvdb::KeyValueDB;
-use types::{Error, ServerKeyId, NodeId};
-use serialization::{SerializablePublic, SerializableSecret, SerializableH256, SerializableAddress};
+use crate::types::{Error, ServerKeyId, NodeId};
+use crate::serialization::{SerializablePublic, SerializableSecret, SerializableH256, SerializableAddress};
 
 /// Encrypted key share, stored by key storage on the single key server.
 #[derive(Debug, Default, Clone, PartialEq)]
@@ -270,9 +271,9 @@ pub mod tests {
 	use std::sync::Arc;
 	use parking_lot::RwLock;
 	use tempdir::TempDir;
-	use crypto::publickey::{Random, Generator, Public};
+	use parity_crypto::publickey::{Random, Generator, Public};
 	use kvdb_rocksdb::{Database, DatabaseConfig};
-	use types::{Error, ServerKeyId};
+	use crate::types::{Error, ServerKeyId};
 	use super::{KeyStorage, PersistentKeyStorage, DocumentKeyShare, DocumentKeyShareVersion};
 
 	/// In-memory document encryption keys storage

--- a/key-server/src/lib.rs
+++ b/key-server/src/lib.rs
@@ -14,46 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity Secret Store.  If not, see <http://www.gnu.org/licenses/>.
 
-extern crate byteorder;
-extern crate ethabi;
-extern crate ethereum_types;
-extern crate hyper;
-extern crate secp256k1;
-extern crate keccak_hash as hash;
-extern crate kvdb;
-extern crate kvdb_rocksdb;
-extern crate parity_bytes as bytes;
-extern crate parity_crypto as crypto;
-extern crate parity_runtime;
-extern crate parking_lot;
-extern crate percent_encoding;
-extern crate rustc_hex;
-extern crate serde;
-extern crate serde_json;
-extern crate tiny_keccak;
-extern crate tokio;
-extern crate tokio_io;
-extern crate tokio_service;
-extern crate url;
-extern crate jsonrpc_server_utils;
-
-extern crate ethabi_derive;
-#[macro_use]
-extern crate ethabi_contract;
-#[macro_use]
-extern crate futures;
-#[macro_use]
-extern crate serde_derive;
-#[macro_use]
-extern crate lazy_static;
-#[macro_use]
-extern crate log;
-
-#[cfg(test)]
-extern crate env_logger;
-#[cfg(test)]
-extern crate tempdir;
-
 mod key_server_cluster;
 mod types;
 
@@ -73,10 +33,10 @@ use kvdb::KeyValueDB;
 use kvdb_rocksdb::{Database, DatabaseConfig};
 use parity_runtime::Executor;
 
-pub use types::{ServerKeyId, EncryptedDocumentKey, RequestSignature, Public,
+pub use crate::types::{ServerKeyId, EncryptedDocumentKey, RequestSignature, Public,
 	Error, NodeAddress, ServiceConfiguration, ClusterConfiguration};
-pub use traits::KeyServer;
-pub use blockchain::{SecretStoreChain, SigningKeyPair, ContractAddress, BlockId, BlockNumber, NewBlocksNotify, Filter};
+pub use crate::traits::KeyServer;
+pub use crate::blockchain::{SecretStoreChain, SigningKeyPair, ContractAddress, BlockId, BlockNumber, NewBlocksNotify, Filter};
 pub use self::node_key_pair::PlainNodeKeyPair;
 
 /// Open a secret store DB using the given secret store data path. The DB path is one level beneath the data path.

--- a/key-server/src/listener/http_listener.rs
+++ b/key-server/src/listener/http_listener.rs
@@ -17,6 +17,7 @@
 use std::collections::BTreeSet;
 use std::sync::{Arc, Weak};
 use futures::future::{ok, result};
+use log::warn;
 use hyper::{self, Uri, Request as HttpRequest, Response as HttpResponse, Method as HttpMethod,
 	StatusCode as HttpStatusCode, Body,
 	header::{self, HeaderValue},
@@ -31,9 +32,9 @@ use parity_runtime::Executor;
 use futures::{future, Future, Stream};
 use percent_encoding::percent_decode;
 
-use traits::KeyServer;
-use serialization::{SerializableEncryptedDocumentKeyShadow, SerializableBytes, SerializablePublic};
-use types::{Error, Public, MessageHash, NodeAddress, RequestSignature, ServerKeyId,
+use crate::traits::KeyServer;
+use crate::serialization::{SerializableEncryptedDocumentKeyShadow, SerializableBytes, SerializablePublic};
+use crate::types::{Error, Public, MessageHash, NodeAddress, RequestSignature, ServerKeyId,
 	EncryptedDocumentKey, EncryptedDocumentKeyShadow, NodeId};
 use jsonrpc_server_utils::cors::{self, AllowCors, AccessControlAllowOrigin};
 
@@ -452,10 +453,10 @@ mod tests {
 	use std::sync::Arc;
 	use std::str::FromStr;
 	use hyper::Method as HttpMethod;
-	use crypto::publickey::Public;
-	use traits::KeyServer;
-	use key_server::tests::DummyKeyServer;
-	use types::NodeAddress;
+	use parity_crypto::publickey::Public;
+	use crate::traits::KeyServer;
+	use crate::key_server::tests::DummyKeyServer;
+	use crate::types::NodeAddress;
 	use parity_runtime::Runtime;
 	use ethereum_types::H256;
 	use super::{parse_request, Request, KeyServerHttpListener};

--- a/key-server/src/listener/mod.rs
+++ b/key-server/src/listener/mod.rs
@@ -23,8 +23,8 @@ mod tasks_queue;
 use std::collections::BTreeSet;
 use std::sync::Arc;
 use futures::Future;
-use traits::{ServerKeyGenerator, DocumentKeyServer, MessageSigner, AdminSessionsServer, KeyServer};
-use types::{Error, Public, MessageHash, EncryptedMessageSignature, RequestSignature, ServerKeyId,
+use crate::traits::{ServerKeyGenerator, DocumentKeyServer, MessageSigner, AdminSessionsServer, KeyServer};
+use crate::types::{Error, Public, MessageHash, EncryptedMessageSignature, RequestSignature, ServerKeyId,
 	EncryptedDocumentKey, EncryptedDocumentKeyShadow, NodeId, Requester};
 
 /// Available API mask.

--- a/key-server/src/listener/service_contract.rs
+++ b/key-server/src/listener/service_contract.rs
@@ -18,16 +18,18 @@ use std::sync::Arc;
 use parking_lot::RwLock;
 use ethabi::RawLog;
 use ethabi::FunctionOutputDecoder;
-use crypto::publickey::{Public, public_to_address};
-use hash::keccak;
-use bytes::Bytes;
+use lazy_static::lazy_static;
+use log::{trace, warn};
+use parity_crypto::publickey::{Public, public_to_address};
+use keccak_hash::keccak;
+use parity_bytes::Bytes;
 use ethereum_types::{H256, U256, Address, H512};
-use listener::ApiMask;
-use listener::service_contract_listener::ServiceTask;
-use blockchain::{SecretStoreChain, Filter, SigningKeyPair, ContractAddress, BlockId};
-use ServerKeyId;
+use crate::listener::ApiMask;
+use crate::listener::service_contract_listener::ServiceTask;
+use crate::blockchain::{SecretStoreChain, Filter, SigningKeyPair, ContractAddress, BlockId};
+use crate::ServerKeyId;
 
-use_contract!(service, "res/service.json");
+ethabi_contract::use_contract!(service, "res/service.json");
 
 /// Name of the general SecretStore contract in the registry.
 pub const SERVICE_CONTRACT_REGISTRY_NAME: &'static str = "secretstore_service";
@@ -723,11 +725,11 @@ fn serialize_threshold(threshold: usize) -> Result<U256, String> {
 #[cfg(test)]
 pub mod tests {
 	use parking_lot::Mutex;
-	use bytes::Bytes;
-	use crypto::publickey::Public;
+	use parity_bytes::Bytes;
+	use parity_crypto::publickey::Public;
 	use ethereum_types::Address;
-	use listener::service_contract_listener::ServiceTask;
-	use {ServerKeyId};
+	use crate::listener::service_contract_listener::ServiceTask;
+	use crate::{ServerKeyId};
 	use super::ServiceContract;
 
 	#[derive(Default)]

--- a/key-server/src/listener/service_contract_aggregate.rs
+++ b/key-server/src/listener/service_contract_aggregate.rs
@@ -15,12 +15,12 @@
 // along with Parity Secret Store.  If not, see <http://www.gnu.org/licenses/>.
 
 use std::sync::Arc;
-use bytes::Bytes;
+use parity_bytes::Bytes;
 use ethereum_types::Address;
-use crypto::publickey::Public;
-use listener::service_contract::ServiceContract;
-use listener::service_contract_listener::ServiceTask;
-use {ServerKeyId};
+use parity_crypto::publickey::Public;
+use crate::listener::service_contract::ServiceContract;
+use crate::listener::service_contract_listener::ServiceTask;
+use crate::{ServerKeyId};
 
 /// Aggregated on-chain service contract.
 pub struct OnChainServiceContractAggregate {

--- a/key-server/src/listener/service_contract_listener.rs
+++ b/key-server/src/listener/service_contract_listener.rs
@@ -18,24 +18,25 @@ use std::collections::HashSet;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::thread;
-use bytes::Bytes;
-use crypto::publickey::{Public, public_to_address};
+use parity_bytes::Bytes;
+use parity_crypto::publickey::{Public, public_to_address};
 use ethereum_types::{H256, U256, Address, BigEndianHash as _};
-use key_server_set::KeyServerSet;
-use key_server_cluster::{NodeId, ClusterClient, ClusterSessionsListener, ClusterSession};
-use key_server_cluster::math;
-use key_server_cluster::generation_session::SessionImpl as GenerationSession;
-use key_server_cluster::encryption_session::{check_encrypted_data, update_encrypted_data};
-use key_server_cluster::decryption_session::SessionImpl as DecryptionSession;
-use key_server_cluster::key_version_negotiation_session::{SessionImpl as KeyVersionNegotiationSession,
+use log::{trace, warn};
+use crate::key_server_set::KeyServerSet;
+use crate::key_server_cluster::{NodeId, ClusterClient, ClusterSessionsListener, ClusterSession};
+use crate::key_server_cluster::math;
+use crate::key_server_cluster::generation_session::SessionImpl as GenerationSession;
+use crate::key_server_cluster::encryption_session::{check_encrypted_data, update_encrypted_data};
+use crate::key_server_cluster::decryption_session::SessionImpl as DecryptionSession;
+use crate::key_server_cluster::key_version_negotiation_session::{SessionImpl as KeyVersionNegotiationSession,
 	IsolatedSessionTransport as KeyVersionNegotiationTransport, FailedContinueAction};
-use key_storage::KeyStorage;
+use crate::key_storage::KeyStorage;
 use parking_lot::Mutex;
-use acl_storage::AclStorage;
-use listener::service_contract::ServiceContract;
-use listener::tasks_queue::TasksQueue;
-use {ServerKeyId, Error};
-use blockchain::{NewBlocksNotify, SigningKeyPair};
+use crate::acl_storage::AclStorage;
+use crate::listener::service_contract::ServiceContract;
+use crate::listener::tasks_queue::TasksQueue;
+use crate::{ServerKeyId, Error};
+use crate::blockchain::{NewBlocksNotify, SigningKeyPair};
 
 /// Retry interval (in blocks). Every RETRY_INTERVAL_BLOCKS blocks each KeyServer reads pending requests from
 /// service contract && tries to re-execute. The reason to have this mechanism is primarily because keys
@@ -580,17 +581,17 @@ fn is_processed_by_this_key_server(key_server_set: &dyn KeyServerSet, node: &Nod
 mod tests {
 	use std::sync::Arc;
 	use std::sync::atomic::Ordering;
-	use crypto::publickey::{Random, Generator, KeyPair};
-	use listener::service_contract::ServiceContract;
-	use listener::service_contract::tests::DummyServiceContract;
-	use key_server_cluster::DummyClusterClient;
-	use acl_storage::{AclStorage, DummyAclStorage};
-	use key_storage::{KeyStorage, DocumentKeyShare};
-	use key_storage::tests::DummyKeyStorage;
-	use key_server_set::KeyServerSet;
-	use key_server_set::tests::MapKeyServerSet;
-	use blockchain::SigningKeyPair;
-	use {PlainNodeKeyPair, ServerKeyId};
+	use parity_crypto::publickey::{Random, Generator, KeyPair};
+	use crate::listener::service_contract::ServiceContract;
+	use crate::listener::service_contract::tests::DummyServiceContract;
+	use crate::key_server_cluster::DummyClusterClient;
+	use crate::acl_storage::{AclStorage, DummyAclStorage};
+	use crate::key_storage::{KeyStorage, DocumentKeyShare};
+	use crate::key_storage::tests::DummyKeyStorage;
+	use crate::key_server_set::KeyServerSet;
+	use crate::key_server_set::tests::MapKeyServerSet;
+	use crate::blockchain::SigningKeyPair;
+	use crate::{PlainNodeKeyPair, ServerKeyId};
 	use super::{ServiceTask, ServiceContractListener, ServiceContractListenerParams, is_processed_by_this_key_server};
 	use ethereum_types::Address;
 

--- a/key-server/src/node_key_pair.rs
+++ b/key-server/src/node_key_pair.rs
@@ -14,9 +14,9 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity Secret Store.  If not, see <http://www.gnu.org/licenses/>.
 
-use crypto::publickey::{KeyPair, Public, Signature, Error as EthKeyError, sign, public_to_address};
+use parity_crypto::publickey::{KeyPair, Public, Signature, Error as EthKeyError, sign, public_to_address};
 use ethereum_types::{H256, Address};
-use blockchain::SigningKeyPair;
+use crate::blockchain::SigningKeyPair;
 
 pub struct PlainNodeKeyPair {
 	key_pair: KeyPair,

--- a/key-server/src/serialization.rs
+++ b/key-server/src/serialization.rs
@@ -19,10 +19,10 @@ use std::ops::Deref;
 use rustc_hex::{self, FromHex};
 use serde::{Serialize, Deserialize, Serializer, Deserializer};
 use serde::de::{Visitor, Error as SerdeError};
-use crypto::publickey::{Public, Secret, Signature};
+use parity_crypto::publickey::{Public, Secret, Signature};
 use ethereum_types::{H160, H256};
-use bytes::Bytes;
-use types::Requester;
+use parity_bytes::Bytes;
+use crate::types::Requester;
 
 trait ToHex {
 	fn to_hex(&self) -> String;

--- a/key-server/src/traits.rs
+++ b/key-server/src/traits.rs
@@ -16,7 +16,7 @@
 
 use std::collections::BTreeSet;
 use futures::Future;
-use types::{Error, Public, ServerKeyId, MessageHash, EncryptedMessageSignature, RequestSignature, Requester,
+use crate::types::{Error, Public, ServerKeyId, MessageHash, EncryptedMessageSignature, RequestSignature, Requester,
 	EncryptedDocumentKey, EncryptedDocumentKeyShadow, NodeId};
 
 /// Server key (SK) generator.

--- a/key-server/src/types/all.rs
+++ b/key-server/src/types/all.rs
@@ -16,23 +16,22 @@
 
 use std::collections::BTreeMap;
 
-use blockchain::ContractAddress;
-use {bytes, ethereum_types};
+use crate::blockchain::ContractAddress;
 
 /// Node id.
-pub type NodeId = crypto::publickey::Public;
+pub type NodeId = parity_crypto::publickey::Public;
 /// Server key id. When key is used to encrypt document, it could be document contents hash.
 pub type ServerKeyId = ethereum_types::H256;
 /// Encrypted document key type.
-pub type EncryptedDocumentKey = bytes::Bytes;
+pub type EncryptedDocumentKey = parity_bytes::Bytes;
 /// Message hash.
 pub type MessageHash = ethereum_types::H256;
 /// Message signature.
-pub type EncryptedMessageSignature = bytes::Bytes;
+pub type EncryptedMessageSignature = parity_bytes::Bytes;
 /// Request signature type.
-pub type RequestSignature = crypto::publickey::Signature;
+pub type RequestSignature = parity_crypto::publickey::Signature;
 /// Public key type.
-pub use crypto::publickey::Public;
+pub use parity_crypto::publickey::Public;
 
 /// Secret store configuration
 #[derive(Debug, Clone)]
@@ -72,7 +71,7 @@ pub struct ClusterConfiguration {
 	/// This node address.
 	pub listener_address: NodeAddress,
 	/// All cluster nodes addresses.
-	pub nodes: BTreeMap<crypto::publickey::Public, NodeAddress>,
+	pub nodes: BTreeMap<parity_crypto::publickey::Public, NodeAddress>,
 	/// Key Server Set contract address. If None, servers from 'nodes' map are used.
 	pub key_server_set_contract_address: Option<ContractAddress>,
 	/// Allow outbound connections to 'higher' nodes.
@@ -89,9 +88,9 @@ pub struct ClusterConfiguration {
 #[derive(Clone, Debug, PartialEq)]
 pub struct EncryptedDocumentKeyShadow {
 	/// Decrypted secret point. It is partially decrypted if shadow decryption was requested.
-	pub decrypted_secret: crypto::publickey::Public,
+	pub decrypted_secret: parity_crypto::publickey::Public,
 	/// Shared common point.
-	pub common_point: Option<crypto::publickey::Public>,
+	pub common_point: Option<parity_crypto::publickey::Public>,
 	/// If shadow decryption was requested: shadow decryption coefficients, encrypted with requestor public.
 	pub decrypt_shadows: Option<Vec<Vec<u8>>>,
 }
@@ -100,9 +99,9 @@ pub struct EncryptedDocumentKeyShadow {
 #[derive(Debug, Clone)]
 pub enum Requester {
 	/// Requested with server key id signature.
-	Signature(crypto::publickey::Signature),
+	Signature(parity_crypto::publickey::Signature),
 	/// Requested with public key.
-	Public(crypto::publickey::Public),
+	Public(parity_crypto::publickey::Public),
 	/// Requested with verified address.
 	Address(ethereum_types::Address),
 }
@@ -116,21 +115,21 @@ impl Default for Requester {
 impl Requester {
 	pub fn public(&self, server_key_id: &ServerKeyId) -> Result<Public, String> {
 		match *self {
-			Requester::Signature(ref signature) => crypto::publickey::recover(signature, server_key_id)
+			Requester::Signature(ref signature) => parity_crypto::publickey::recover(signature, server_key_id)
 				.map_err(|e| format!("bad signature: {}", e)),
 			Requester::Public(ref public) => Ok(public.clone()),
 			Requester::Address(_) => Err("cannot recover public from address".into()),
 		}
 	}
 
-	pub fn address(&self, server_key_id: &ServerKeyId) -> Result<crypto::publickey::Address, String> {
+	pub fn address(&self, server_key_id: &ServerKeyId) -> Result<parity_crypto::publickey::Address, String> {
 		self.public(server_key_id)
-			.map(|p| crypto::publickey::public_to_address(&p))
+			.map(|p| parity_crypto::publickey::public_to_address(&p))
 	}
 }
 
-impl From<crypto::publickey::Signature> for Requester {
-	fn from(signature: crypto::publickey::Signature) -> Requester {
+impl From<parity_crypto::publickey::Signature> for Requester {
+	fn from(signature: parity_crypto::publickey::Signature) -> Requester {
 		Requester::Signature(signature)
 	}
 }

--- a/key-server/src/types/error.rs
+++ b/key-server/src/types/error.rs
@@ -17,8 +17,7 @@
 use std::fmt;
 use std::net;
 use std::io::Error as IoError;
-
-use crypto;
+use serde::{Deserialize, Serialize};
 
 /// Secret store error.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -162,14 +161,14 @@ impl fmt::Display for Error {
 	}
 }
 
-impl From<crypto::publickey::Error> for Error {
-	fn from(err: crypto::publickey::Error) -> Self {
+impl From<parity_crypto::publickey::Error> for Error {
+	fn from(err: parity_crypto::publickey::Error) -> Self {
 		Error::EthKey(err.into())
 	}
 }
 
-impl From<crypto::Error> for Error {
-	fn from(err: crypto::Error) -> Self {
+impl From<parity_crypto::Error> for Error {
+	fn from(err: parity_crypto::Error) -> Self {
 		Error::EthKey(err.to_string())
 	}
 }


### PR DESCRIPTION
part of #4 

This is quite a large, but trivial PR, which is required to use `async` functions in key-server.