### PR TITLE
Introduce substrate service

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,5 +5,6 @@ members = [
 	"http-service",
 	"key-server",
 	"primitives",
+	"substrate-service",
 	"substrate-runtime/runtime",
 ]

--- a/substrate-service/Cargo.toml
+++ b/substrate-service/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "parity-secretstore-substrate-service"
+version = "1.0.0"
+license = "GPL-3.0"
+authors = ["Parity Technologies <admin@parity.io>"]
+edition = "2018"
+
+[dependencies]
+futures = "0.3"
+log = "0.4"
+parity-crypto = { version = "0.5", features = ["publickey"] }
+blockchain-service = { package = "parity-secretstore-blockchain-service", path = "../blockchain-service" }
+primitives = { package = "parity-secretstore-primitives", path = "../primitives" }

--- a/substrate-service/src/lib.rs
+++ b/substrate-service/src/lib.rs
@@ -1,0 +1,335 @@
+// Copyright 2015-2020 Parity Technologies (UK) Ltd.
+// This file is part of Parity Secret Store.
+
+// Parity Secret Store is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity Secret Store is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity Secret Store.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::{
+	collections::{BTreeSet, VecDeque},
+	ops::Range,
+	sync::Arc,
+};
+use futures::{FutureExt, Stream, StreamExt};
+use log::error;
+use primitives::{
+	Address, KeyServerId, Public, ServerKeyId,
+	error::Error,
+	executor::Executor,
+	key_server::KeyServer,
+	key_storage::KeyStorage,
+	service::ServiceTasksListenerRegistrar,
+};
+use crate::{
+	transaction_pool::SubstrateTransactionPool,
+};
+
+// hide blockchain-service dependency
+pub use blockchain_service::Configuration;
+
+pub type BlockchainServiceTask = blockchain_service::BlockchainServiceTask;
+
+mod transaction_pool;
+
+/// Substrate block id.
+pub enum BlockId<Hash> {
+	/// Use block referenced by the hash.
+	Hash(Hash),
+	/// Use best known block.
+	Best,
+}
+
+/// Block event that is maybe an event coming from SecretStore runtime module.
+pub trait MaybeSecretStoreEvent {
+	/// Try convert to secret store event.
+	fn as_secret_store_event(self) -> Option<BlockchainServiceTask>;
+}
+
+/// Substrate Secret Store module calls.
+#[derive(Debug)]
+pub enum SecretStoreCall {
+	/// Called when server key is generated.
+	ServerKeyGenerated(ServerKeyId, Public),
+	/// Called when server key generation error happens.
+	ServerKeyGenerationError(ServerKeyId),
+	/// Called when server key is retrieved.
+	ServerKeyRetrieved(ServerKeyId, Public, u8),
+	/// Called when server key retrieval error happens.
+	ServerKeyRetrievalError(ServerKeyId),
+	/// Called when document key is stored.
+	DocumentKeyStored(ServerKeyId),
+	/// Called when document key store error happens.
+	DocumentKeyStoreError(ServerKeyId),
+	/// Called when document key common part is retrieved.
+	DocumentKeyCommonRetrieved(ServerKeyId, Address, Public, u8),
+	/// Called when document key personal part is retrieved.
+	DocumentKeyPersonalRetrieved(ServerKeyId, Address, Vec<Address>, Public, Vec<u8>),
+	/// Called when document key shadow retireval error happens.
+	DocumentKeyShadowRetrievalError(ServerKeyId, Address),
+}
+
+/// Substrate blockchain.
+pub trait Blockchain: 'static + Send + Sync {
+	/// Block hash type.
+	type BlockHash: Clone + Send + Sync;
+	/// Blockchain event type.
+	type Event: MaybeSecretStoreEvent;
+	/// Block events iterator type.
+	type BlockEvents: IntoIterator<Item = Self::Event>;
+	/// Pending events iterator type.
+	type PendingEvents: IntoIterator<Item = Self::Event>;
+
+	/// Get block events.
+	fn block_events(&self, block_hash: Self::BlockHash) -> Self::BlockEvents;
+	/// Get current key servers set. This should return current key servers set at the best
+	/// known (finalized) block. That's because we use this to determine key server which
+	/// will should start corresponding session AND the session starts at the time when
+	/// current set should have been read from the best block.
+	fn current_key_servers_set(&self) -> BTreeSet<KeyServerId>;
+
+	/// Get pending server key generation tasks range at given block.
+	fn server_key_generation_tasks(
+		&self,
+		block_hash: Self::BlockHash,
+		range: Range<usize>,
+	) -> Result<Self::PendingEvents, String>;
+	/// Is server key generation request response required?
+	fn is_server_key_generation_response_required(
+		&self,
+		key_id: ServerKeyId,
+		key_server_id: KeyServerId,
+	) -> Result<bool, String>;
+
+	/// Get pending server key retrieval tasks range at given block.
+	fn server_key_retrieval_tasks(
+		&self,
+		block_hash: Self::BlockHash,
+		range: Range<usize>,
+	) -> Result<Self::PendingEvents, String>;
+	/// Is server key retrieval request response required?
+	fn is_server_key_retrieval_response_required(
+		&self,
+		key_id: ServerKeyId,
+		key_server_id: KeyServerId,
+	) -> Result<bool, String>;
+
+	/// Get pending document key store tasks range at given block.
+	fn document_key_store_tasks(
+		&self,
+		block_hash: Self::BlockHash,
+		range: Range<usize>,
+	) -> Result<Self::PendingEvents, String>;
+	/// Is document key store request response required?
+	fn is_document_key_store_response_required(
+		&self,
+		key_id: ServerKeyId,
+		key_server_id: KeyServerId,
+	) -> Result<bool, String>;
+
+	/// Get pending document key shadow retrieval tasks range at given block.
+	fn document_key_shadow_retrieval_tasks(
+		&self,
+		block_hash: Self::BlockHash,
+		range: Range<usize>,
+	) -> Result<Self::PendingEvents, String>;
+	/// Is document key shadow retrieval request response required?
+	fn is_document_key_shadow_retrieval_response_required(
+		&self,
+		key_id: ServerKeyId,
+		requester: Address,
+		key_server_id: KeyServerId,
+	) -> Result<bool, String>;
+}
+
+/// Transaction pool API.
+pub trait TransactionPool: Send + Sync + 'static {
+	/// Transaction hash.
+	type TransactionHash: std::fmt::Display;
+
+	/// Submit transaction to the pool.
+	fn submit_transaction(&self, call: SecretStoreCall) -> Result<Self::TransactionHash, String>;
+}
+
+/// Substrate block passed to the blockchain service.
+struct SubstrateBlock<B: Blockchain> {
+	/// Origin block.
+	pub block_hash: B::BlockHash,
+	/// Shared blockchain reference.
+	pub blockchain: Arc<B>,
+	/// This server key address.
+	pub key_server_address: Address,
+}
+
+/// Start listening requests from given contract.
+pub fn start_service<B, E, TP, KSrv, KStr>(
+	key_server: Arc<KSrv>,
+	key_storage: Arc<KStr>,
+	listener_registrar: Arc<dyn ServiceTasksListenerRegistrar>,
+	blockchain: Arc<B>,
+	executor: Arc<E>,
+	transaction_pool: Arc<TP>,
+	config: Configuration,
+	new_blocks_stream: impl Stream<Item = B::BlockHash> + Send + 'static,
+) -> Result<(), Error> where
+	B: Blockchain,
+	E: Executor,
+	TP: TransactionPool,
+	KSrv: KeyServer,
+	KStr: KeyStorage,
+{
+//	let config = Arc::new(config);
+	let key_server_address = config.self_id;
+	let transaction_pool = Arc::new(SubstrateTransactionPool::new(
+		blockchain.clone(),
+		transaction_pool,
+		key_server_address.clone(),
+	));
+	let new_blocks_future = blockchain_service::start_service(
+		key_server,
+		key_storage,
+		listener_registrar,
+		executor.clone(),
+		transaction_pool,
+		config,
+		new_blocks_stream
+			.map(move |block_hash| SubstrateBlock {
+				block_hash,
+				blockchain: blockchain.clone(),
+				key_server_address: key_server_address.clone(),
+			})
+	);
+	executor.spawn(new_blocks_future
+		.map(|err| error!(
+			target: "secretstore",
+			"Blockhain service future failed: {:?}",
+			err,
+		))
+		.boxed()
+	);
+	Ok(())
+}
+
+impl<B: Blockchain> blockchain_service::Block for SubstrateBlock<B> {
+	type NewBlocksIterator = Box<dyn Iterator<Item = BlockchainServiceTask>>;
+	type PendingBlocksIterator = Box<dyn Iterator<Item = BlockchainServiceTask>>;
+
+	fn new_tasks(&self) -> Self::NewBlocksIterator {
+		Box::new(
+			self.blockchain
+				.block_events(self.block_hash.clone())
+				.into_iter()
+				.filter_map(MaybeSecretStoreEvent::as_secret_store_event)
+		)
+	}
+
+	fn pending_tasks(&self) -> Self::PendingBlocksIterator {
+		let (blockchain, block_hash) = (self.blockchain.clone(), self.block_hash.clone());
+		let server_key_generation_tasks = move |tasks: &mut VecDeque<BlockchainServiceTask>, range|
+			Ok(tasks.extend(
+				blockchain
+					.server_key_generation_tasks(block_hash.clone(), range)?
+					.into_iter()
+					.filter_map(MaybeSecretStoreEvent::as_secret_store_event)
+			));
+		let (blockchain, block_hash) = (self.blockchain.clone(), self.block_hash.clone());
+		let server_key_retrieval_tasks = move |tasks: &mut VecDeque<BlockchainServiceTask>, range|
+			Ok(tasks.extend(
+				blockchain
+					.server_key_retrieval_tasks(block_hash.clone(), range)?
+					.into_iter()
+					.filter_map(MaybeSecretStoreEvent::as_secret_store_event)
+			));
+		let (blockchain, block_hash) = (self.blockchain.clone(), self.block_hash.clone());
+		let document_key_store_tasks = move |tasks: &mut VecDeque<BlockchainServiceTask>, range|
+			Ok(tasks.extend(
+				blockchain
+					.document_key_store_tasks(block_hash.clone(), range)?
+					.into_iter()
+					.filter_map(MaybeSecretStoreEvent::as_secret_store_event)
+			));
+		let (blockchain, block_hash) = (self.blockchain.clone(), self.block_hash.clone());
+		let document_key_shadow_retrieval_tasks = move |tasks: &mut VecDeque<BlockchainServiceTask>, range|
+			Ok(tasks.extend(
+				blockchain
+					.document_key_shadow_retrieval_tasks(block_hash.clone(), range)?
+					.into_iter()
+					.filter_map(MaybeSecretStoreEvent::as_secret_store_event)
+			));
+
+		Box::new(
+			PendingTasksIterator {
+				pending: VecDeque::new(),
+				range: 0..std::usize::MAX,
+				get_pending_tasks: server_key_generation_tasks,
+			}.chain(PendingTasksIterator {
+				pending: VecDeque::new(),
+				range: 0..std::usize::MAX,
+				get_pending_tasks: server_key_retrieval_tasks,
+			}).chain(PendingTasksIterator {
+				pending: VecDeque::new(),
+				range: 0..std::usize::MAX,
+				get_pending_tasks: document_key_store_tasks,
+			}).chain(PendingTasksIterator {
+				pending: VecDeque::new(),
+				range: 0..std::usize::MAX,
+				get_pending_tasks: document_key_shadow_retrieval_tasks,
+			})
+		)
+	}
+
+	fn current_key_servers_set(&self) -> BTreeSet<KeyServerId> {
+		self.blockchain.current_key_servers_set()
+	}
+}
+
+struct PendingTasksIterator<F> {
+	pending: VecDeque<BlockchainServiceTask>,
+	range: Range<usize>,
+	get_pending_tasks: F,
+}
+
+impl<F> Iterator for PendingTasksIterator<F>
+	where
+		F: Fn(&mut VecDeque<BlockchainServiceTask>, Range<usize>) -> Result<(), String>,
+{
+	type Item = BlockchainServiceTask;
+
+	fn next(&mut self) -> Option<Self::Item> {
+		const PENDING_RANGE_LENGTH: usize = 16;
+
+		loop {
+			if let Some(pending_task) = self.pending.pop_front() {
+				return Some(pending_task);
+			}
+
+			if self.range.start == self.range.end {
+				return None;
+			}
+
+			let next_range_start = self.range.start + PENDING_RANGE_LENGTH;
+			let pending_range = self.range.start..next_range_start;
+			if let Err(error) = (self.get_pending_tasks)(&mut self.pending, pending_range) {
+				error!(
+					target: "secretstore",
+					"Failed to read pending tasks: {}",
+					error,
+				);
+			}
+
+			if self.pending.len() == PENDING_RANGE_LENGTH {
+				self.range = next_range_start..self.range.end;
+			} else {
+				self.range = self.range.end..self.range.end;
+			}
+		}
+	}
+}

--- a/substrate-service/src/transaction_pool.rs
+++ b/substrate-service/src/transaction_pool.rs
@@ -1,0 +1,318 @@
+// Copyright 2015-2020 Parity Technologies (UK) Ltd.
+// This file is part of Parity Secret Store.
+
+// Parity Secret Store is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity Secret Store is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity Secret Store.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::sync::Arc;
+use log::{error, trace};
+use primitives::{
+	Address, ServerKeyId,
+	key_server::{
+		ServerKeyGenerationArtifacts, ServerKeyRetrievalArtifacts,
+		DocumentKeyCommonRetrievalArtifacts, DocumentKeyShadowRetrievalArtifacts,
+	},
+	requester::Requester,
+};
+use crate::{
+	Blockchain, SecretStoreCall, TransactionPool,
+};
+
+/// Substrate transction pool.
+pub struct SubstrateTransactionPool<B, P> {
+	/// Shared blockchain reference.
+	blockchain: Arc<B>,
+	/// Shared reference to actual transaction pool.
+	transaction_pool: Arc<P>,
+	/// This key server address.
+	key_server_address: Address,
+}
+
+impl<B, P> SubstrateTransactionPool<B, P>
+	where
+		B: Blockchain,
+		P: TransactionPool,
+{
+	/// Create new transaction pool.
+	pub fn new(
+		blockchain: Arc<B>,
+		transaction_pool: Arc<P>,
+		key_server_address: Address,
+	) -> Self {
+		SubstrateTransactionPool {
+			blockchain,
+			transaction_pool,
+			key_server_address,
+		}
+	}
+
+	/// Send response transaction if required.
+	fn submit_response_transaction(
+		&self,
+		format_request: impl Fn() -> String,
+		is_response_required: impl FnOnce() -> Result<bool, String>,
+		prepare_response: impl FnOnce() -> Result<SecretStoreCall, String>,
+	) {
+		match is_response_required() {
+			Ok(true) => (),
+			Ok(false) => {
+				trace!(
+					target: "secretstore",
+					"Response {} is not required. Transaction is not submitted.",
+					format_request(),
+				);
+
+				return
+			},
+			Err(error) => error!(
+				target: "secretstore",
+				"Failed to check if response {} is required: {}",
+				format_request(),
+				error,
+			),
+		}
+
+		let submit_result = prepare_response()
+			.and_then(|transaction| self
+				.transaction_pool
+				.submit_transaction(transaction)
+			);
+
+		match submit_result {
+			Ok(transaction_hash) => trace!(
+				target: "secretstore",
+				"Submitted response {}: {}",
+				format_request(),
+				transaction_hash,
+			),
+			Err(error) => error!(
+				target: "secretstore",
+				"Failed to submit response {}: {}",
+				format_request(),
+				error,
+			),
+		}
+	}
+}
+
+impl<B, P> blockchain_service::TransactionPool
+	for
+		SubstrateTransactionPool<B, P>
+	where
+		B: Blockchain,
+		P: TransactionPool,
+{
+	fn publish_generated_server_key(
+		&self,
+		_origin: Address,
+		key_id: ServerKeyId,
+		artifacts: ServerKeyGenerationArtifacts,
+	) {
+		self.submit_response_transaction(
+			|| format!("ServerKeyGenerationSuccess({})", key_id),
+			|| self.blockchain.is_server_key_generation_response_required(key_id, self.key_server_address),
+			|| Ok(SecretStoreCall::ServerKeyGenerated(key_id, artifacts.key)),
+		)
+	}
+
+	fn publish_server_key_generation_error(&self, _origin: Address, key_id: ServerKeyId) {
+		self.submit_response_transaction(
+			|| format!("ServerKeyGenerationFailure({})", key_id),
+			|| self.blockchain.is_server_key_generation_response_required(key_id, self.key_server_address),
+			|| Ok(SecretStoreCall::ServerKeyGenerationError(key_id)),
+		)
+	}
+
+	fn publish_retrieved_server_key(
+		&self,
+		_origin: Address,
+		key_id: ServerKeyId,
+		artifacts: ServerKeyRetrievalArtifacts,
+	) {
+		self.submit_response_transaction(
+			|| format!("ServerKeyRetrievalSuccess({})", key_id),
+			|| self.blockchain.is_server_key_retrieval_response_required(key_id, self.key_server_address),
+			|| serialize_threshold(artifacts.threshold)
+				.map(|threshold| SecretStoreCall::ServerKeyRetrieved(key_id, artifacts.key, threshold)),
+		)
+	}
+
+	fn publish_server_key_retrieval_error(&self, _origin: Address, key_id: ServerKeyId) {
+		self.submit_response_transaction(
+			|| format!("ServerKeyRetrievalFailure({})", key_id),
+			|| self.blockchain.is_server_key_retrieval_response_required(key_id, self.key_server_address),
+			|| Ok(SecretStoreCall::ServerKeyRetrievalError(key_id)),
+		)
+	}
+
+	fn publish_stored_document_key(&self, _origin: Address, key_id: ServerKeyId) {
+		self.submit_response_transaction(
+			|| format!("DocumentKeyStoreSuccess({})", key_id),
+			|| self.blockchain.is_document_key_store_response_required(key_id, self.key_server_address),
+			|| Ok(SecretStoreCall::DocumentKeyStored(key_id)),
+		)
+	}
+
+	fn publish_document_key_store_error(&self, _origin: Address, key_id: ServerKeyId) {
+		self.submit_response_transaction(
+			|| format!("DocumentKeyStoreFailure({})", key_id),
+			|| self.blockchain.is_document_key_store_response_required(key_id, self.key_server_address),
+			|| Ok(SecretStoreCall::DocumentKeyStoreError(key_id)),
+		)
+	}
+
+	fn publish_retrieved_document_key_common(
+		&self,
+		_origin: Address,
+		key_id: ServerKeyId,
+		requester: Requester,
+		artifacts: DocumentKeyCommonRetrievalArtifacts,
+	) {
+		self.submit_response_transaction(
+			|| format!("DocumentKeyCommonRetrievalSuccess({}, {})", key_id, requester),
+			|| requester
+				.address(&key_id)
+				.map_err(Into::into)
+				.and_then(|requester|
+					self.blockchain
+						.is_document_key_shadow_retrieval_response_required(
+							key_id,
+							requester,
+							self.key_server_address,
+						)
+				),
+			|| serialize_threshold(artifacts.threshold)
+				.and_then(|threshold|
+					requester
+						.address(&key_id)
+						.map_err(Into::into)
+						.map(|requester| (threshold, requester))
+				)
+				.map(|(threshold, requester)| SecretStoreCall::DocumentKeyCommonRetrieved(
+					key_id,
+					requester,
+					artifacts.common_point,
+					threshold,
+				)),
+		)
+	}
+
+	fn publish_document_key_common_retrieval_error(
+		&self,
+		_origin: Address,
+		key_id: ServerKeyId,
+		requester: Requester,
+	) {
+		self.submit_response_transaction(
+			|| format!("DocumentKeyCommonRetrievalFailure({}, {})", key_id, requester),
+			|| requester
+				.address(&key_id)
+				.map_err(Into::into)
+				.and_then(|requester|
+					self.blockchain
+						.is_document_key_shadow_retrieval_response_required(
+							key_id,
+							requester,
+							self.key_server_address,
+						)
+				),
+			|| requester
+				.address(&key_id)
+				.map_err(Into::into)
+				.map(|requester| SecretStoreCall::DocumentKeyShadowRetrievalError(
+					key_id,
+					requester,
+				)),
+		)
+	}
+
+	fn publish_retrieved_document_key_personal(
+		&self,
+		_origin: Address,
+		key_id: ServerKeyId,
+		requester: Requester,
+		artifacts: DocumentKeyShadowRetrievalArtifacts,
+	) {
+		self.submit_response_transaction(
+			|| format!("DocumentKeyPersonalRetrievalSuccess({}, {})", key_id, requester),
+			|| requester
+				.address(&key_id)
+				.map_err(Into::into)
+				.and_then(|requester|
+					self.blockchain
+						.is_document_key_shadow_retrieval_response_required(
+							key_id,
+							requester,
+							self.key_server_address,
+						)
+				),
+			|| {
+				let self_coefficient = artifacts
+					.participants_coefficients
+					.get(&self.key_server_address)
+					.cloned()
+					.ok_or_else(|| String::from(
+						"DocumentKeyPersonalRetrieval session has completed without self coefficient",
+					))?;
+
+				requester
+					.address(&key_id)
+					.map_err(Into::into)
+					.map(|requester| SecretStoreCall::DocumentKeyPersonalRetrieved(
+						key_id,
+						requester,
+						artifacts.participants_coefficients.keys().cloned().collect::<Vec<_>>(),
+						artifacts.encrypted_document_key,
+						self_coefficient,
+					))
+			},
+		)
+	}
+
+	fn publish_document_key_personal_retrieval_error(
+		&self,
+		_origin: Address,
+		key_id: ServerKeyId,
+		requester: Requester,
+	) {
+		self.submit_response_transaction(
+			|| format!("DocumentKeyPersonalRetrievalFailure({}, {})", key_id, requester),
+			|| requester
+				.address(&key_id)
+				.map_err(Into::into)
+				.and_then(|requester|
+					self.blockchain
+						.is_document_key_shadow_retrieval_response_required(
+							key_id,
+							requester,
+							self.key_server_address,
+						)
+				),
+			|| requester
+				.address(&key_id)
+				.map_err(Into::into)
+				.map(|requester| SecretStoreCall::DocumentKeyShadowRetrievalError(
+					key_id,
+					requester,
+				)),
+		)
+	}
+}
+
+/// Serialize threshold (we only support 256 KS at max).
+pub fn serialize_threshold(threshold: usize) -> Result<u8, String> {
+	if threshold > ::std::u8::MAX as usize {
+		return Err(format!("invalid threshold to use in service contract: {}", threshold));
+	}
+	Ok(threshold as _)
+}


### PR DESCRIPTION
(last major, pre-binary) part of #4 

This PR introduces substrate service, which is built on top of blockchain-service. It is much less useful than ethereum-service, because we need to deal with different runtimes (which means different calls encoding, different transactions encoding, ...) here. So most of code will still reside in substrate binary (which, I hope, will be easy-configurable for using in different chains, though).