### PR TITLE
Avoid blocking on futures where possible (in services)

### DIFF
--- a/ethereum-service/src/server_key_generation.rs
+++ b/ethereum-service/src/server_key_generation.rs
@@ -15,6 +15,7 @@
 // along with Parity Secret Store.  If not, see <http://www.gnu.org/licenses/>.
 
 use std::sync::Arc;
+use futures::{Stream, StreamExt};
 use ethabi::{FunctionOutputDecoder, RawLog};
 use ethereum_types::{Address, H256, U256};
 use keccak_hash::keccak;
@@ -70,42 +71,41 @@ impl ServerKeyGenerationService {
 
 	/// Create iterator over pending server key retrieval requests.
 	pub fn create_pending_requests_iterator<B: Blockchain>(
-		blockchain: &Arc<B>,
-		config: &Arc<Configuration>,
-		block: &H256,
-		contract_address: &Address,
-		key_server_address: &Address,
-	) -> impl Iterator<Item=BlockchainServiceTask> {
+		blockchain: Arc<B>,
+		config: Arc<Configuration>,
+		block: H256,
+		contract_address: Address,
+		key_server_address: Address,
+	) -> impl Stream<Item=BlockchainServiceTask> + Send {
 		let iterator = match config.server_key_generation_requests {
-			true => Box::new(create_typed_pending_requests_iterator(
-				&blockchain,
-				&block,
-				&contract_address,
-				&key_server_address,
+			true => create_typed_pending_requests_iterator(
+				blockchain,
+				block,
+				contract_address,
+				key_server_address,
 				&Self::read_pending_requests_count,
 				&Self::read_pending_request,
-			)) as Box<dyn Iterator<Item=BlockchainServiceTask>>,
-			false => Box::new(::std::iter::empty()),
+			).boxed(),
+			false => futures::stream::empty().boxed(),
 		};
 
 		iterator
 	}
 
 	/// Check if response from key server is required.
-	pub fn is_response_required<B: Blockchain>(
-		blockchain: &B,
-		contract_address: &Address,
-		key_id: &ServerKeyId,
-		key_server_address: &Address,
+	pub async fn is_response_required<B: Blockchain>(
+		blockchain: Arc<B>,
+		contract_address: Address,
+		key_id: ServerKeyId,
+		key_server_address: Address,
 	) -> Result<bool, String> {
 		// we're checking confirmation in Latest block, because we're interested in latest contract state here
 		let (encoded, decoder) = service::functions::is_server_key_generation_response_required::call(
-			*key_id,
-			*key_server_address,
+			key_id,
+			key_server_address,
 		);
-		blockchain
-			.contract_call(BlockId::Best, *contract_address, encoded)
-			.and_then(|encoded| decoder.decode(&encoded).map_err(|e| e.to_string()))
+		let call_result = blockchain.contract_call(BlockId::Best, contract_address, encoded).await?;
+		decoder.decode(&call_result).map_err(|e| e.to_string())
 	}
 
 	/// Prepare publish key transaction data.
@@ -122,41 +122,38 @@ impl ServerKeyGenerationService {
 	}
 
 	/// Read pending requests count.
-	fn read_pending_requests_count<B: Blockchain>(
-		blockchain: &B,
-		block: &H256,
-		contract_address: &Address,
+	async fn read_pending_requests_count<B: Blockchain>(
+		blockchain: Arc<B>,
+		block: H256,
+		contract_address: Address,
 	) -> Result<U256, String> {
 		let (encoded, decoder) = service::functions::server_key_generation_requests_count::call();
-		decoder
-			.decode(&blockchain.contract_call(BlockId::Hash(*block), *contract_address, encoded)?)
-			.map_err(|e| e.to_string())
+		let call_result = blockchain.contract_call(BlockId::Hash(block), contract_address, encoded).await?;
+		decoder.decode(&call_result).map_err(|e| e.to_string())
 	}
 
 	/// Read pending request.
-	fn read_pending_request<B: Blockchain>(
-		blockchain: &B,
-		block: &H256,
-		key_server_address: &Address,
-		contract_address: &Address,
+	async fn read_pending_request<B: Blockchain>(
+		blockchain: Arc<B>,
+		block: H256,
+		key_server_address: Address,
+		contract_address: Address,
 		index: U256,
 	) -> Result<(bool, BlockchainServiceTask), String> {
 		let (encoded, decoder) = service::functions::get_server_key_generation_request::call(index);
-		let (key_id, author, threshold) = decoder
-			.decode(&blockchain.contract_call(BlockId::Hash(*block), *contract_address, encoded)?)
-			.map_err(|e| e.to_string())?;
+		let call_result = blockchain.contract_call(BlockId::Hash(block), contract_address, encoded).await?;
+		let (key_id, author, threshold) = decoder.decode(&call_result).map_err(|e| e.to_string())?;
 		let threshold = parse_threshold(threshold)?;
 
 		let (encoded, decoder) = service::functions::is_server_key_generation_response_required::call(
 			key_id,
-			*key_server_address,
+			key_server_address,
 		);
-		let not_confirmed = decoder
-			.decode(&blockchain.contract_call(BlockId::Hash(*block), *contract_address, encoded)?)
-			.map_err(|e| e.to_string())?;
+		let call_result = blockchain.contract_call(BlockId::Hash(block), contract_address, encoded).await?;
+		let not_confirmed = decoder.decode(&call_result).map_err(|e| e.to_string())?;
 
 		let task = BlockchainServiceTask::Regular(
-			*contract_address,
+			contract_address,
 			ServiceTask::GenerateServerKey(
 				key_id,
 				Requester::Address(author),

--- a/ethereum-service/src/server_key_retrieval.rs
+++ b/ethereum-service/src/server_key_retrieval.rs
@@ -15,6 +15,7 @@
 // along with Parity Secret Store.  If not, see <http://www.gnu.org/licenses/>.
 
 use std::sync::Arc;
+use futures::{Stream, StreamExt};
 use ethabi::{FunctionOutputDecoder, RawLog};
 use ethereum_types::{Address, H256, U256};
 use keccak_hash::keccak;
@@ -68,42 +69,41 @@ impl ServerKeyRetrievalService {
 
 	/// Create iterator over pending server key retrieval requests.
 	pub fn create_pending_requests_iterator<B: Blockchain>(
-		blockchain: &Arc<B>,
-		config: &Arc<Configuration>,
-		block: &H256,
-		contract_address: &Address,
-		key_server_address: &Address,
-	) -> impl Iterator<Item=BlockchainServiceTask> {
+		blockchain: Arc<B>,
+		config: Arc<Configuration>,
+		block: H256,
+		contract_address: Address,
+		key_server_address: Address,
+	) -> impl Stream<Item=BlockchainServiceTask> + Send {
 		let iterator = match config.server_key_retrieval_requests {
-			true => Box::new(create_typed_pending_requests_iterator(
-				&blockchain,
-				&block,
-				&contract_address,
-				&key_server_address,
+			true => create_typed_pending_requests_iterator(
+				blockchain,
+				block,
+				contract_address,
+				key_server_address,
 				&Self::read_pending_requests_count,
 				&Self::read_pending_request,
-			)) as Box<dyn Iterator<Item=BlockchainServiceTask>>,
-			false => Box::new(::std::iter::empty()),
+			).boxed(),
+			false => futures::stream::empty().boxed(),
 		};
 
 		iterator
 	}
 
 	/// Check if response from key server is required.
-	pub fn is_response_required<B: Blockchain>(
-		blockchain: &B,
-		contract_address: &Address,
-		key_id: &ServerKeyId,
-		key_server_address: &Address,
+	pub async fn is_response_required<B: Blockchain>(
+		blockchain: Arc<B>,
+		contract_address: Address,
+		key_id: ServerKeyId,
+		key_server_address: Address,
 	) -> Result<bool, String> {
 		// we're checking confirmation in Latest block, because we're interested in latest contract state here
 		let (encoded, decoder) = service::functions::is_server_key_retrieval_response_required::call(
-			*key_id,
-			*key_server_address,
+			key_id,
+			key_server_address,
 		);
-		blockchain
-			.contract_call(BlockId::Best, *contract_address, encoded)
-			.and_then(|encoded| decoder.decode(&encoded).map_err(|e| e.to_string()))
+		let call_result = blockchain.contract_call(BlockId::Best, contract_address, encoded).await?;
+		decoder.decode(&call_result).map_err(|e| e.to_string())
 	}
 
 	/// Prepare publish key transaction data.
@@ -121,40 +121,37 @@ impl ServerKeyRetrievalService {
 	}
 
 	/// Read pending requests count.
-	fn read_pending_requests_count<B: Blockchain>(
-		blockchain: &B,
-		block: &H256,
-		contract_address: &Address,
+	async fn read_pending_requests_count<B: Blockchain>(
+		blockchain: Arc<B>,
+		block: H256,
+		contract_address: Address,
 	) -> Result<U256, String> {
 		let (encoded, decoder) = service::functions::server_key_retrieval_requests_count::call();
-		decoder
-			.decode(&blockchain.contract_call(BlockId::Hash(*block), *contract_address, encoded)?)
-			.map_err(|e| e.to_string())
+		let call_result = blockchain.contract_call(BlockId::Hash(block), contract_address, encoded).await?;
+		decoder.decode(&call_result).map_err(|e| e.to_string())
 	}
 
 	/// Read pending request.
-	fn read_pending_request<B: Blockchain>(
-		blockchain: &B,
-		block: &H256,
-		key_server_address: &Address,
-		contract_address: &Address,
+	async fn read_pending_request<B: Blockchain>(
+		blockchain: Arc<B>,
+		block: H256,
+		key_server_address: Address,
+		contract_address: Address,
 		index: U256,
 	) -> Result<(bool, BlockchainServiceTask), String> {
 		let (encoded, decoder) = service::functions::get_server_key_retrieval_request::call(index);
-		let key_id = decoder
-			.decode(&blockchain.contract_call(BlockId::Hash(*block), *contract_address, encoded)?)
-			.map_err(|e| e.to_string())?;
+		let call_result = blockchain.contract_call(BlockId::Hash(block), contract_address, encoded).await?;
+		let key_id = decoder.decode(&call_result).map_err(|e| e.to_string())?;
 
 		let (encoded, decoder) = service::functions::is_server_key_retrieval_response_required::call(
 			key_id,
-			*key_server_address,
+			key_server_address,
 		);
-		let not_confirmed = decoder
-			.decode(&blockchain.contract_call(BlockId::Hash(*block), *contract_address, encoded)?)
-			.map_err(|e| e.to_string())?;
+		let call_result = blockchain.contract_call(BlockId::Hash(block), contract_address, encoded).await?;
+		let not_confirmed = decoder.decode(&call_result).map_err(|e| e.to_string())?;
 
 		let task = BlockchainServiceTask::Regular(
-			*contract_address,
+			contract_address,
 			ServiceTask::RetrieveServerKey(
 				key_id,
 				None,

--- a/ethereum-service/src/transaction_pool.rs
+++ b/ethereum-service/src/transaction_pool.rs
@@ -15,11 +15,13 @@
 // along with Parity Secret Store.  If not, see <http://www.gnu.org/licenses/>.
 
 use std::sync::Arc;
+use futures::future::{Future, FutureExt, TryFutureExt, lazy, ready};
 use log::{error, trace};
 use ethereum_types::Address;
 use parity_bytes::Bytes;
 use primitives::{
 	ServerKeyId,
+	executor::Executor,
 	key_server::{
 		ServerKeyGenerationArtifacts, ServerKeyRetrievalArtifacts,
 		DocumentKeyCommonRetrievalArtifacts, DocumentKeyShadowRetrievalArtifacts,
@@ -36,7 +38,9 @@ use crate::{
 };
 
 /// Ethereum transction pool.
-pub struct EthereumTransactionPool<B, P> {
+pub struct EthereumTransactionPool<E, B, P> {
+	/// Futures executor.
+	executor: Arc<E>,
 	/// Shared blockchain reference.
 	blockchain: Arc<B>,
 	/// Shared reference to actual transaction pool.
@@ -45,18 +49,21 @@ pub struct EthereumTransactionPool<B, P> {
 	key_server_address: Address,
 }
 
-impl<B, P> EthereumTransactionPool<B, P>
+impl<E, B, P> EthereumTransactionPool<E, B, P>
 	where
+		E: Executor,
 		B: Blockchain,
 		P: TransactionPool,
 {
 	/// Create new transaction pool.
 	pub fn new(
+		executor: Arc<E>,
 		blockchain: Arc<B>,
 		transaction_pool: Arc<P>,
 		key_server_address: Address,
 	) -> Self {
 		EthereumTransactionPool {
+			executor,
 			blockchain,
 			transaction_pool,
 			key_server_address,
@@ -66,52 +73,59 @@ impl<B, P> EthereumTransactionPool<B, P>
 	/// Send response transaction if required.
 	fn submit_response_transaction(
 		&self,
-		contract_address: &Address,
-		format_request: impl Fn() -> String,
-		is_response_required: impl FnOnce() -> Result<bool, String>,
-		prepare_response: impl FnOnce() -> Result<Bytes, String>,
+		contract_address: Address,
+		formatted_request: String,
+		is_response_required: impl Future<Output = Result<bool, String>> + Send + 'static,
+		prepare_response: impl Future<Output = Result<Bytes, String>> + Send + 'static,
 	) {
-		match is_response_required() {
-			Ok(true) => (),
-			Ok(false) => return,
-			Err(error) => error!(
-				target: "secretstore",
-				"Failed to check if response {} at {} is required: {}",
-				format_request(),
-				contract_address,
-				error,
-			),
-		}
+		let transaction_pool = self.transaction_pool.clone();
+		let submit_transaction_future = async move {
+			match is_response_required.await {
+				Ok(true) => (),
+				Ok(false) => return,
+				Err(error) => {
+					error!(
+						target: "secretstore",
+						"Failed to check if response {} at {} is required: {}",
+						formatted_request,
+						contract_address,
+						error,
+					);
 
-		let submit_result = prepare_response()
-			.and_then(|transaction| self
-				.transaction_pool
-				.submit_transaction(transaction)
-			);
+					return
+				},
+			}
 
-		match submit_result {
-			Ok(transaction_hash) => trace!(
-				target: "secretstore",
-				"Submitted response {} at {}: {}",
-				format_request(),
-				contract_address,
-				transaction_hash,
-			),
-			Err(error) => error!(
-				target: "secretstore",
-				"Failed to submit response {} at {}: {}",
-				format_request(),
-				contract_address,
-				error,
-			),
-		}
+			let submit_result = prepare_response
+				.and_then(|transaction| transaction_pool.submit_transaction(transaction))
+				.await;
+			match submit_result {
+				Ok(transaction_hash) => trace!(
+					target: "secretstore",
+					"Submitted response {} at {}: {}",
+					formatted_request,
+					contract_address,
+					transaction_hash,
+				),
+				Err(error) => error!(
+					target: "secretstore",
+					"Failed to submit response {} at {}: {}",
+					formatted_request,
+					contract_address,
+					error,
+				),
+			}
+		};
+
+		self.executor.spawn(submit_transaction_future.boxed());
 	}
 }
 
-impl<B, P> blockchain_service::TransactionPool
+impl<E, B, P> blockchain_service::TransactionPool
 	for
-		EthereumTransactionPool<B, P>
+		EthereumTransactionPool<E, B, P>
 	where
+		E: Executor,
 		B: Blockchain,
 		P: TransactionPool,
 {
@@ -122,29 +136,34 @@ impl<B, P> blockchain_service::TransactionPool
 		artifacts: ServerKeyGenerationArtifacts,
 	) {
 		self.submit_response_transaction(
-			&contract_address,
-			|| format!("ServerKeyGenerationSuccess({})", key_id),
-			|| ServerKeyGenerationService::is_response_required(
-				&*self.blockchain,
-				&contract_address,
-				&key_id,
-				&self.key_server_address,
+			contract_address,
+			format!("ServerKeyGenerationSuccess({})", key_id),
+			ServerKeyGenerationService::is_response_required(
+				self.blockchain.clone(),
+				contract_address,
+				key_id,
+				self.key_server_address,
 			),
-			|| Ok(ServerKeyGenerationService::prepare_pubish_tx_data(&key_id, &artifacts.key)),
+			lazy(move |_| Ok(ServerKeyGenerationService::prepare_pubish_tx_data(
+				&key_id,
+				&artifacts.key,
+			))),
 		)
 	}
 
 	fn publish_server_key_generation_error(&self, contract_address: Address, key_id: ServerKeyId) {
 		self.submit_response_transaction(
-			&contract_address,
-			|| format!("ServerKeyGenerationFailure({})", key_id),
-			|| ServerKeyGenerationService::is_response_required(
-				&*self.blockchain,
-				&contract_address,
-				&key_id,
-				&self.key_server_address,
+			contract_address,
+			format!("ServerKeyGenerationFailure({})", key_id),
+			ServerKeyGenerationService::is_response_required(
+				self.blockchain.clone(),
+				contract_address,
+				key_id,
+				self.key_server_address,
 			),
-			|| Ok(ServerKeyGenerationService::prepare_error_tx_data(&key_id)),
+			lazy(move |_| Ok(ServerKeyGenerationService::prepare_error_tx_data(
+				&key_id,
+			))),
 		)
 	}
 
@@ -155,62 +174,69 @@ impl<B, P> blockchain_service::TransactionPool
 		artifacts: ServerKeyRetrievalArtifacts,
 	) {
 		self.submit_response_transaction(
-			&contract_address,
-			|| format!("ServerKeyRetrievalSuccess({})", key_id),
-			|| ServerKeyRetrievalService::is_response_required(
-				&*self.blockchain,
-				&contract_address,
-				&key_id,
-				&self.key_server_address,
+			contract_address,
+			format!("ServerKeyRetrievalSuccess({})", key_id),
+			ServerKeyRetrievalService::is_response_required(
+				self.blockchain.clone(),
+				contract_address,
+				key_id,
+				self.key_server_address,
 			),
-			|| serialize_threshold(artifacts.threshold)
+			lazy(move |_| serialize_threshold(artifacts.threshold)
 				.map(|threshold| ServerKeyRetrievalService::prepare_pubish_tx_data(
 					&key_id,
 					&artifacts.key,
 					threshold)
-				),
+				)
+			),
 		)
 	}
 
 	fn publish_server_key_retrieval_error(&self, contract_address: Address, key_id: ServerKeyId) {
 		self.submit_response_transaction(
-			&contract_address,
-			|| format!("ServerKeyRetrievalFailure({})", key_id),
-			|| ServerKeyRetrievalService::is_response_required(
-				&*self.blockchain,
-				&contract_address,
-				&key_id,
-				&self.key_server_address,
+			contract_address,
+			format!("ServerKeyRetrievalFailure({})", key_id),
+			ServerKeyRetrievalService::is_response_required(
+				self.blockchain.clone(),
+				contract_address,
+				key_id,
+				self.key_server_address,
 			),
-			|| Ok(ServerKeyRetrievalService::prepare_error_tx_data(&key_id)),
+			lazy(move |_| Ok(ServerKeyRetrievalService::prepare_error_tx_data(
+				&key_id,
+			))),
 		)
 	}
 
 	fn publish_stored_document_key(&self, contract_address: Address, key_id: ServerKeyId) {
 		self.submit_response_transaction(
-			&contract_address,
-			|| format!("DocumentKeyStoreSuccess({})", key_id),
-			|| DocumentKeyStoreService::is_response_required(
-				&*self.blockchain,
-				&contract_address,
-				&key_id,
-				&self.key_server_address,
+			contract_address,
+			format!("DocumentKeyStoreSuccess({})", key_id),
+			DocumentKeyStoreService::is_response_required(
+				self.blockchain.clone(),
+				contract_address,
+				key_id,
+				self.key_server_address,
 			),
-			|| Ok(DocumentKeyStoreService::prepare_pubish_tx_data(&key_id)),
+			lazy(move |_| Ok(DocumentKeyStoreService::prepare_pubish_tx_data(
+				&key_id,
+			))),
 		)
 	}
 
 	fn publish_document_key_store_error(&self, contract_address: Address, key_id: ServerKeyId) {
 		self.submit_response_transaction(
-			&contract_address,
-			|| format!("DocumentKeyStoreFailure({})", key_id),
-			|| DocumentKeyStoreService::is_response_required(
-				&*self.blockchain,
-				&contract_address,
-				&key_id,
-				&self.key_server_address,
+			contract_address,
+			format!("DocumentKeyStoreFailure({})", key_id),
+			DocumentKeyStoreService::is_response_required(
+				self.blockchain.clone(),
+				contract_address,
+				key_id,
+				self.key_server_address,
 			),
-			|| Ok(DocumentKeyStoreService::prepare_error_tx_data(&key_id)),
+			lazy(move |_| Ok(DocumentKeyStoreService::prepare_error_tx_data(
+				&key_id,
+			))),
 		)
 	}
 
@@ -221,20 +247,20 @@ impl<B, P> blockchain_service::TransactionPool
 		requester: Requester,
 		artifacts: DocumentKeyCommonRetrievalArtifacts,
 	) {
+		let blockchain = self.blockchain.clone();
+		let key_server_address = self.key_server_address;
 		self.submit_response_transaction(
-			&contract_address,
-			|| format!("DocumentKeyCommonRetrievalSuccess({}, {})", key_id, requester),
-			|| requester
-				.address(&key_id)
-				.map_err(Into::into)
-				.and_then(|requester| DocumentKeyShadowRetrievalService::is_response_required(
-					&*self.blockchain,
-					&contract_address,
-					&key_id,
-					&requester,
-					&self.key_server_address,
+			contract_address,
+			format!("DocumentKeyCommonRetrievalSuccess({}, {})", key_id, requester),
+			ready(requester.address(&key_id).map_err(Into::into))
+				.and_then(move |requester| DocumentKeyShadowRetrievalService::is_response_required(
+					blockchain,
+					contract_address,
+					key_id,
+					requester,
+					key_server_address,
 				)),
-			|| serialize_threshold(artifacts.threshold)
+			lazy(move |_| serialize_threshold(artifacts.threshold)
 				.and_then(|threshold| requester
 					.address(&key_id)
 					.map_err(Into::into)
@@ -245,7 +271,7 @@ impl<B, P> blockchain_service::TransactionPool
 					&requester,
 					&artifacts.common_point,
 					threshold,
-				)),
+				))),
 		)
 	}
 
@@ -255,25 +281,25 @@ impl<B, P> blockchain_service::TransactionPool
 		key_id: ServerKeyId,
 		requester: Requester,
 	) {
+		let blockchain = self.blockchain.clone();
+		let key_server_address = self.key_server_address;
 		self.submit_response_transaction(
-			&contract_address,
-			|| format!("DocumentKeyCommonRetrievalFailure({}, {})", key_id, requester),
-			|| requester
-				.address(&key_id)
-				.map_err(Into::into)
-				.and_then(|requester| DocumentKeyShadowRetrievalService::is_response_required(
-					&*self.blockchain,
-					&contract_address,
-					&key_id,
-					&requester,
-					&self.key_server_address,
+			contract_address,
+			format!("DocumentKeyCommonRetrievalFailure({}, {})", key_id, requester),
+			ready(requester.address(&key_id).map_err(Into::into))
+				.and_then(move |requester| DocumentKeyShadowRetrievalService::is_response_required(
+					blockchain,
+					contract_address,
+					key_id,
+					requester,
+					key_server_address,
 				)),
-			|| requester
+			lazy(move |_| requester
 				.address(&key_id)
 				.map_err(Into::into)
 				.map(|requester|
 					DocumentKeyShadowRetrievalService::prepare_error_tx_data(&key_id, &requester)
-				),
+				)),
 		)
 	}
 
@@ -284,40 +310,42 @@ impl<B, P> blockchain_service::TransactionPool
 		requester: Requester,
 		artifacts: DocumentKeyShadowRetrievalArtifacts,
 	) {
+		let blockchain = self.blockchain.clone();
+		let key_server_address = self.key_server_address;
+		let blockchain_copy = blockchain.clone();
+		let artifacts_copy = artifacts.clone();
 		self.submit_response_transaction(
-			&contract_address,
-			|| format!("DocumentKeyPersonalRetrievalSuccess({}, {})", key_id, requester),
-			|| requester
-				.address(&key_id)
-				.map_err(Into::into)
-				.and_then(|requester| DocumentKeyShadowRetrievalService::is_response_required(
-					&*self.blockchain,
-					&contract_address,
-					&key_id,
-					&requester,
-					&self.key_server_address,
+			contract_address,
+			format!("DocumentKeyPersonalRetrievalSuccess({}, {})", key_id, requester),
+			ready(requester.address(&key_id).map_err(Into::into))
+				.and_then(move |requester| DocumentKeyShadowRetrievalService::is_response_required(
+					blockchain,
+					contract_address,
+					key_id,
+					requester,
+					key_server_address,
 				)),
-			|| {
-				let self_coefficient = artifacts
-					.participants_coefficients
-					.get(&self.key_server_address)
-					.cloned()
-					.ok_or_else(|| String::from(
-						"DocumentKeyPersonalRetrieval session has completed without self coefficient",
-					))?;
-				requester
-					.address(&key_id)
-					.map_err(Into::into)
-					.and_then(|requester| DocumentKeyShadowRetrievalService::prepare_pubish_personal_tx_data(
-						&*self.blockchain,
-						&contract_address,
-						&key_id,
-						&requester,
-						&artifacts.participants_coefficients.keys().cloned().collect::<Vec<_>>()[..],
-						artifacts.encrypted_document_key,
-						self_coefficient,
-					))
-			},
+			lazy(move |_| artifacts
+				.participants_coefficients
+				.get(&key_server_address)
+				.cloned()
+				.ok_or_else(|| String::from(
+					"DocumentKeyPersonalRetrieval session has completed without self coefficient",
+				)))
+			.and_then(move |self_coefficient| ready(requester
+				.address(&key_id)
+				.map(|requester| (self_coefficient, requester))
+				.map_err(Into::into))
+			)
+			.and_then(move |(self_coefficient, requester)| DocumentKeyShadowRetrievalService::prepare_pubish_personal_tx_data(
+				blockchain_copy,
+				contract_address,
+				key_id,
+				requester,
+				artifacts_copy.participants_coefficients.keys().cloned().collect(),
+				artifacts_copy.encrypted_document_key,
+				self_coefficient,
+			)),
 		)
 	}
 
@@ -327,25 +355,26 @@ impl<B, P> blockchain_service::TransactionPool
 		key_id: ServerKeyId,
 		requester: Requester,
 	) {
+		let blockchain = self.blockchain.clone();
+		let key_server_address = self.key_server_address;
 		self.submit_response_transaction(
-			&contract_address,
-			|| format!("DocumentKeyPersonalRetrievalFailure({}, {})", key_id, requester),
-			|| requester
-				.address(&key_id)
-				.map_err(Into::into)
-				.and_then(|requester| DocumentKeyShadowRetrievalService::is_response_required(
-					&*self.blockchain,
-					&contract_address,
-					&key_id,
-					&requester,
-					&self.key_server_address,
+			contract_address,
+			format!("DocumentKeyPersonalRetrievalFailure({}, {})", key_id, requester),
+			ready(requester.address(&key_id).map_err(Into::into))
+				.and_then(move |requester| DocumentKeyShadowRetrievalService::is_response_required(
+					blockchain,
+					contract_address,
+					key_id,
+					requester,
+					key_server_address,
 				)),
-			|| requester
+			lazy(move |_| requester
 				.address(&key_id)
 				.map_err(Into::into)
 				.map(|requester|
 					DocumentKeyShadowRetrievalService::prepare_error_tx_data(&key_id, &requester)
-				),
+				)
+			),
 		)
 	}
 }


### PR DESCRIPTION
This PR mostly switches from `Iterator` to `Stream` when returning tasks in blockchain services to avoid blocking on futures in runtime threads. Unfortunately, we'll still need this, because core SS code (sessions) is not adopted for futures and we still need to call into Acl and KeyServerSet methods (which will result in async RPC calls) from their code. But this PR decreases potential number of waits to minimum.

This PR is required for introducing service-bounded binaries.