### PR TITLE
Introduce SecretStore for Substrate binary

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
+	"bin/substrate",
 	"bin/substrate-node",
 	"blockchain-service",
 	"ethereum-service",

--- a/bin/substrate-node/Cargo.toml
+++ b/bin/substrate-node/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 
 [dependencies]
+jsonrpc-core = "14.0.3"
 structopt = "0.3.8"
 sc-basic-authorship = "0.8.0-alpha.3"
 sc-cli = "0.8.0-alpha.3"
@@ -12,6 +13,7 @@ sc-client = "0.8.0-alpha.3"
 sc-consensus-aura = "0.8.0-alpha.3"
 sc-executor = "0.8.0-alpha.3"
 sc-finality-grandpa = "0.8.0-alpha.3"
+sc-rpc = "2.0.0-alpha.3"
 sc-transaction-pool = "2.0.0-alpha.3"
 sc-service = "0.8.0-alpha.3"
 sp-consensus = "0.8.0-alpha.3"
@@ -20,6 +22,7 @@ sp-core = "2.0.0-alpha.3"
 sp-finality-grandpa = "2.0.0-alpha.3"
 sp-inherents = "2.0.0-alpha.3"
 sp-runtime = "2.0.0-alpha.3"
+substrate-frame-rpc-system = "2.0.0-alpha.3"
 secretstore-runtime = { package = "parity-secretstore-substrate-runtime", path = "../../substrate-runtime/runtime" }
 
 [build-dependencies]

--- a/bin/substrate-node/src/chain_spec.rs
+++ b/bin/substrate-node/src/chain_spec.rs
@@ -75,8 +75,12 @@ impl Alternative {
 					vec![
 						get_account_id_from_seed::<sr25519::Public>("Alice"),
 						get_account_id_from_seed::<sr25519::Public>("Bob"),
+						get_account_id_from_seed::<sr25519::Public>("Charlie"),
+						get_account_id_from_seed::<sr25519::Public>("Dave"),
 						get_account_id_from_seed::<sr25519::Public>("Alice//stash"),
 						get_account_id_from_seed::<sr25519::Public>("Bob//stash"),
+						get_account_id_from_seed::<sr25519::Public>("Charlie//stash"),
+						get_account_id_from_seed::<sr25519::Public>("Dave//stash"),
 					],
 					true,
 				),
@@ -97,10 +101,12 @@ impl Alternative {
 	}
 }
 
-fn testnet_genesis(initial_authorities: Vec<(AuraId, GrandpaId)>,
+fn testnet_genesis(
+	initial_authorities: Vec<(AuraId, GrandpaId)>,
 	root_key: AccountId,
 	endowed_accounts: Vec<AccountId>,
-	_enable_println: bool) -> GenesisConfig {
+	_enable_println: bool,
+) -> GenesisConfig {
 	GenesisConfig {
 		frame_system: Some(SystemConfig {
 			code: WASM_BINARY.to_vec(),

--- a/bin/substrate-node/src/service.rs
+++ b/bin/substrate-node/src/service.rs
@@ -74,6 +74,15 @@ macro_rules! new_full_start {
 				import_setup = Some((grandpa_block_import, grandpa_link));
 
 				Ok(import_queue)
+			})?
+			.with_rpc_extensions(|builder| -> Result<jsonrpc_core::IoHandler<sc_rpc::Metadata>, _> {
+				use substrate_frame_rpc_system::{FullSystem, SystemApi};
+
+				let mut io = jsonrpc_core::IoHandler::default();
+				io.extend_with(
+					SystemApi::to_delegate(FullSystem::new(builder.client().clone(), builder.pool()))
+				);
+				Ok(io)
 			})?;
 
 		(builder, import_setup, inherent_data_providers)

--- a/bin/substrate/Cargo.toml
+++ b/bin/substrate/Cargo.toml
@@ -1,0 +1,45 @@
+[package]
+name = "parity-secretstore-substrate"
+version = "1.0.0"
+authors = ["Parity Technologies <admin@parity.io>"]
+edition = "2018"
+
+[dependencies]
+
+# utilitarian dependencies
+
+ansi_term = "0.9"
+clap = { version = "2.33", features = ["yaml"] }
+codec = { package = "parity-scale-codec", version = "1.0" }
+env_logger = "0.7"
+futures = { version = "0.3", features = ["thread-pool"] }
+hex = "0.4"
+jsonrpsee = { git = "https://github.com/paritytech/jsonrpsee.git", features = ["ws"] }
+log = "0.4"
+parity-crypto = { version = "0.5", features = ["publickey"] }
+parking_lot = "0.9"
+serde = { version = "1.0", features = ["derive"] }
+serde_with = "1.4"
+serde_json = "1.0"
+time = "0.1"
+toml = "0.5"
+
+# direct substrate references
+
+frame-system = "2.0.0-alpha.3"
+pallet-transaction-payment = "2.0.0-alpha.3"
+sp-core = "2.0.0-alpha.3"
+sp-runtime = "2.0.0-alpha.3"
+sp-version = "2.0.0-alpha.3"
+
+# internal secret store references
+
+key-server = { package = "parity-secretstore-key-server", path = "../../key-server" }
+primitives = { package = "parity-secretstore-primitives", path = "../../primitives" }
+substrate-runtime = { package = "parity-secretstore-substrate-runtime", path = "../../substrate-runtime/runtime" }
+substrate-service = { package = "parity-secretstore-substrate-service", path = "../../substrate-service" }
+runtime-module = { package = "parity-secretstore-substrate-runtime-module", path = "../../substrate-runtime/module" }
+runtime-primitives = { package = "parity-secretstore-substrate-runtime-primitives", path = "../../substrate-runtime/primitives" }
+
+[dev-dependencies]
+tempdir = "0.3"

--- a/bin/substrate/README.md
+++ b/bin/substrate/README.md
@@ -1,0 +1,28 @@
+# Secret Store for Substrate
+
+More docs will be added later...
+
+## Quick start
+
+```bash
+#!/bin/bash
+set -e
+
+rm -rf db
+rm -rf ssdb.1
+rm -rf ssdb.2
+rm -rf ssdb.3
+rm -rf ssdb.4
+
+cargo build --manifest-path=../secret-store/Cargo.toml -p parity-secretstore-substrate-node
+cp ../secret-store/target/debug/parity-secretstore-substrate-node .
+cargo build --manifest-path=../secret-store/Cargo.toml -p parity-secretstore-substrate
+cp ../secret-store/target/debug/parity-secretstore-substrate .
+
+RUST_LOG=sc_rpc=trace,txpool=trace,txqueue=trace unbuffer ./parity-secretstore-substrate-node --dev --base-path db 2>&1 | unbuffer -p gawk '{ print strftime("Node: [%Y-%m-%d %H:%M:%S]"), $0 }' | unbuffer -p tee ssnode.log&
+sleep 10
+RUST_LOG=secretstore=trace,secretstore_net=trace unbuffer ./parity-secretstore-substrate --self-secret=0101010101010101010101010101010101010101010101010101010101010101 --db-path=ssdb.1 --net-port=10000 --sub-signer=//Alice 2>&1 | unbuffer -p gawk '{ print strftime("Alice: [%Y-%m-%d %H:%M:%S]"), $0 }' | unbuffer -p tee ssalice.log&
+RUST_LOG=secretstore=trace,secretstore_net=trace unbuffer ./parity-secretstore-substrate --self-secret=0202020202020202020202020202020202020202020202020202020202020202 --db-path=ssdb.2 --net-port=10001 --sub-signer=//Bob 2>&1 | unbuffer -p gawk '{ print strftime("Bob: [%Y-%m-%d %H:%M:%S]"), $0 }' | unbuffer -p tee ssbob.log&
+RUST_LOG=secretstore=trace,secretstore_net=trace unbuffer ./parity-secretstore-substrate --self-secret=0303030303030303030303030303030303030303030303030303030303030303 --db-path=ssdb.3 --net-port=10002 --sub-signer=//Charlie 2>&1 | unbuffer -p gawk '{ print strftime("Charlie: [%Y-%m-%d %H:%M:%S]"), $0 }' | unbuffer -p tee sscharlie.log&
+RUST_LOG=secretstore=trace,secretstore_net=trace unbuffer ./parity-secretstore-substrate --self-secret=0404040404040404040404040404040404040404040404040404040404040404 --db-path=ssdb.4 --net-port=10003 --sub-signer=//Dave 2>&1 | unbuffer -p gawk '{ print strftime("Dave: [%Y-%m-%d %H:%M:%S]"), $0 }' | unbuffer -p tee ssdave.log&
+```

--- a/bin/substrate/src/acl_storage.rs
+++ b/bin/substrate/src/acl_storage.rs
@@ -1,0 +1,49 @@
+// Copyright 2015-2020 Parity Technologies (UK) Ltd.
+// This file is part of Parity Secret Store.
+
+// Parity Secret Store is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity Secret Store is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity Secret Store.  If not, see <http://www.gnu.org/licenses/>.
+
+use codec::Encode;
+use primitives::{
+	Address, ServerKeyId,
+	acl_storage::AclStorage,
+	error::Error,
+};
+use crate::substrate_client::{BlockRef, Client};
+
+pub struct OnChainAclStorage {
+	client: Client,
+}
+
+impl OnChainAclStorage {
+	/// Crate new on-chain ACL storage.
+	pub fn new(client: Client) -> Self {
+		OnChainAclStorage {
+			client,
+		}
+	}
+}
+
+impl AclStorage for OnChainAclStorage {
+	fn check(&self, requester_address: Address, server_key_id: &ServerKeyId) -> Result<bool, Error> {
+		// we always check at best block - there's no need to use deprecated ACLs
+		futures::executor::block_on(async {
+			self.client.call_runtime_method(
+				BlockRef::LocalBest,
+				"SecretStoreAclApi_check",
+				(requester_address, server_key_id).encode(),
+			).await.map_err(|err| Error::Internal(format!("{:?}", err)))
+		})
+	}
+}

--- a/bin/substrate/src/arguments.rs
+++ b/bin/substrate/src/arguments.rs
@@ -1,0 +1,275 @@
+// Copyright 2015-2020 Parity Technologies (UK) Ltd.
+// This file is part of Parity Secret Store.
+
+// Parity Secret Store is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity Secret Store is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity Secret Store.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::str::FromStr;
+use serde::Deserialize;
+use parity_crypto::publickey::Secret;
+
+/// Program arguments. Read either from CLI arguments, or from configuration file
+#[derive(Debug, PartialEq)]
+pub struct Arguments {
+	pub self_secret: Secret,
+	pub db_path: String,
+	pub net_host: String,
+	pub net_port: u16,
+	pub sub_host: String,
+	pub sub_port: u16,
+	pub sub_signer: String,
+	pub sub_signer_password: Option<String>,
+}
+
+/// Program arguments that may be stored in configuration file.
+#[derive(Default, Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct TomlArguments {
+	#[serde(default, rename = "self-secret", with = "opt_secret")]
+	self_secret: Option<Secret>,
+	#[serde(default, rename = "db-path")]
+	db_path: Option<String>,
+	#[serde(default, rename = "net-host")]
+	net_host: Option<String>,
+	#[serde(default, rename = "net-port")]
+	net_port: Option<u16>,
+	#[serde(default, rename = "sub-host")]
+	sub_host: Option<String>,
+	#[serde(default, rename = "sub-port")]
+	sub_port: Option<u16>,
+	#[serde(default, rename = "sub-signer")]
+	sub_signer: Option<String>,
+	#[serde(default, rename = "sub-signer-password")]
+	sub_signer_password: Option<String>,
+}
+
+// we can't use `#[serde(with)]` on `Option<>` fields => we need custom deserializer
+mod opt_secret {
+	use parity_crypto::publickey::Secret;
+	use serde::{Deserialize, Deserializer};
+
+	pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<Secret>, D::Error>
+	where
+		D: Deserializer<'de>,
+	{
+		#[derive(Deserialize)]
+		struct Helper(#[serde(with = "serde_with::rust::display_fromstr")] Secret);
+
+		let helper = Option::deserialize(deserializer)?;
+		Ok(helper.map(|Helper(secret)| secret))
+	}
+}
+
+/// Parse command line arguments.
+pub fn parse_arguments<'a>(
+	args: Option<Vec<&'a str>>,
+) -> Result<Arguments, String> {
+	let yaml = clap::load_yaml!("cli.yml");
+	let clap_app = clap::App::from_yaml(yaml);
+	let matches = match args {
+		Some(args) => clap_app.get_matches_from(args),
+		None => clap_app.get_matches(),
+	};
+
+	let toml_arguments: TomlArguments = match matches.value_of("config") {
+		Some(config_file_path) => std::fs::read_to_string(config_file_path)
+			.map_err(|err| format!("{}", err))
+			.and_then(|file_contents| toml::from_str(&file_contents)
+				.map_err(|err| format!("{}", err))
+			)?,
+		None => Default::default(),
+	};
+
+	Ok(Arguments {
+		self_secret: matches.value_of("self-secret")
+			.map(|self_secret| Secret::from_str(self_secret).map_err(|err| format!("{}", err)))
+			.or_else(|| toml_arguments.self_secret.clone().map(Ok))
+			.ok_or_else(|| String::from("Key server secret key must be specified"))??,
+		db_path: matches.value_of("db-path")
+			.map(str::to_owned)
+			.or_else(|| toml_arguments.db_path.clone())
+			.unwrap_or_else(|| "db".into()),
+		net_host: matches.value_of("net-host")
+			.map(str::to_owned)
+			.or_else(|| toml_arguments.net_host.clone())
+			.unwrap_or_else(|| "0.0.0.0".into()),
+		net_port: matches.value_of("net-port")
+			.map(|net_port| u16::from_str(net_port).map_err(|err| format!("{}", err)))
+			.or_else(|| toml_arguments.net_port.clone().map(Ok))
+			.unwrap_or_else(|| Ok(8083))?,
+		sub_host: matches.value_of("sub-host")
+			.map(str::to_owned)
+			.or_else(|| toml_arguments.sub_host.clone())
+			.unwrap_or_else(|| "localhost".into()),
+		sub_port: matches.value_of("sub-port")
+			.map(|sub_port| u16::from_str(sub_port).map_err(|err| format!("{}", err)))
+			.or_else(|| toml_arguments.sub_port.clone().map(Ok))
+			.unwrap_or_else(|| Ok(9933))?,
+		sub_signer: matches.value_of("sub-signer")
+			.map(str::to_owned)
+			.or_else(|| toml_arguments.sub_signer.clone())
+			.unwrap_or_else(|| "//Alice".into()),
+		sub_signer_password: matches.value_of("sub-signer-password")
+			.map(str::to_owned)
+			.or_else(|| toml_arguments.sub_signer_password.clone()),
+	})
+}
+
+#[cfg(test)]
+mod tests {
+	use std::io::Write;
+	use super::*;
+
+	#[test]
+	fn arguments_read_some_from_cli() {
+		assert_eq!(
+			parse_arguments(Some(vec![
+				"parity-secretstore-substrate",
+				"--self-secret=0101010101010101010101010101010101010101010101010101010101010101",
+				"--net-host=nethost.com",
+				"--sub-port=4242",
+				"--sub-signer=//Bob",
+			])),
+			Ok(Arguments {
+				self_secret: Secret::from([1u8; 32]),
+				db_path: "db".into(),
+				net_host: "nethost.com".into(),
+				net_port: 8083,
+				sub_host: "localhost".into(),
+				sub_port: 4242,
+				sub_signer: "//Bob".into(),
+				sub_signer_password: None,
+			}),
+		);
+	}
+
+	#[test]
+	fn arguments_read_full_from_cli() {
+		assert_eq!(
+			parse_arguments(Some(vec![
+				"parity-secretstore-substrate",
+				"--self-secret=0101010101010101010101010101010101010101010101010101010101010101",
+				"--db-path=mydb",
+				"--net-host=nethost.com",
+				"--net-port=42",
+				"--sub-host=subhost.com",
+				"--sub-port=4242",
+				"--sub-signer=//Bob",
+				"--sub-signer-password=password",
+			])),
+			Ok(Arguments {
+				self_secret: Secret::from([1u8; 32]),
+				db_path: "mydb".into(),
+				net_host: "nethost.com".into(),
+				net_port: 42,
+				sub_host: "subhost.com".into(),
+				sub_port: 4242,
+				sub_signer: "//Bob".into(),
+				sub_signer_password: Some("password".into()),
+			}),
+		);
+	}
+
+	#[test]
+	fn arguments_read_some_from_file() {
+		let temp_dir = tempdir::TempDir::new("arguments_read_from_file").unwrap();
+		let temp_file_path = temp_dir.path().join("config.toml");
+		std::fs::File::create(temp_file_path.clone()).unwrap().write_all(r#"
+net-host = "nethost.com"
+sub-port = 4242
+sub-signer = "//Bob"
+		"#.as_bytes()).unwrap();
+
+		assert_eq!(
+			parse_arguments(Some(vec![
+				"parity-secretstore-substrate",
+				"--config",
+				temp_file_path.to_str().unwrap(),
+				"--self-secret",
+				"0101010101010101010101010101010101010101010101010101010101010101",
+			])),
+			Ok(Arguments {
+				self_secret: Secret::from([1u8; 32]),
+				db_path: "db".into(),
+				net_host: "nethost.com".into(),
+				net_port: 8083,
+				sub_host: "localhost".into(),
+				sub_port: 4242,
+				sub_signer: "//Bob".into(),
+				sub_signer_password: None,
+			}),
+		);
+	}
+
+	#[test]
+	fn arguments_read_full_from_file() {
+		let temp_dir = tempdir::TempDir::new("arguments_read_from_file").unwrap();
+		let temp_file_path = temp_dir.path().join("config.toml");
+		std::fs::File::create(temp_file_path.clone()).unwrap().write_all(r#"
+self-secret = "0101010101010101010101010101010101010101010101010101010101010101"
+db-path = "mydb"
+net-host = "nethost.com"
+net-port = 42
+sub-host = "subhost.com"
+sub-port = 4242
+sub-signer = "//Bob"
+sub-signer-password = "password"
+		"#.as_bytes()).unwrap();
+
+		assert_eq!(
+			parse_arguments(Some(vec![
+				"parity-secretstore-substrate",
+				"--config",
+				temp_file_path.to_str().unwrap(),
+			])),
+			Ok(Arguments {
+				self_secret: Secret::from([1u8; 32]),
+				db_path: "mydb".into(),
+				net_host: "nethost.com".into(),
+				net_port: 42,
+				sub_host: "subhost.com".into(),
+				sub_port: 4242,
+				sub_signer: "//Bob".into(),
+				sub_signer_password: Some("password".into()),
+			}),
+		);
+	}
+
+	#[test]
+	fn arguments_from_cli_overrides_arguments_from_file() {
+		let temp_dir = tempdir::TempDir::new("arguments_read_from_file").unwrap();
+		let temp_file_path = temp_dir.path().join("config.toml");
+		std::fs::File::create(temp_file_path.clone()).unwrap().write_all(r#"
+self-secret = "0202020202020202020202020202020202020202020202020202020202020202"
+		"#.as_bytes()).unwrap();
+
+		assert_eq!(
+			parse_arguments(Some(vec![
+				"parity-secretstore-substrate",
+				"--config",
+				temp_file_path.to_str().unwrap(),
+				"--self-secret=0101010101010101010101010101010101010101010101010101010101010101",
+			])),
+			Ok(Arguments {
+				self_secret: Secret::from([1u8; 32]),
+				db_path: "db".into(),
+				net_host: "0.0.0.0".into(),
+				net_port: 8083,
+				sub_host: "localhost".into(),
+				sub_port: 9933,
+				sub_signer: "//Alice".into(),
+				sub_signer_password: None,
+			}),
+		);
+	}
+}

--- a/bin/substrate/src/arguments.rs
+++ b/bin/substrate/src/arguments.rs
@@ -266,7 +266,7 @@ self-secret = "0202020202020202020202020202020202020202020202020202020202020202"
 				net_host: "0.0.0.0".into(),
 				net_port: 8083,
 				sub_host: "localhost".into(),
-				sub_port: 9933,
+				sub_port: 9944,
 				sub_signer: "//Alice".into(),
 				sub_signer_password: None,
 			}),

--- a/bin/substrate/src/arguments.rs
+++ b/bin/substrate/src/arguments.rs
@@ -114,7 +114,7 @@ pub fn parse_arguments<'a>(
 		sub_port: matches.value_of("sub-port")
 			.map(|sub_port| u16::from_str(sub_port).map_err(|err| format!("{}", err)))
 			.or_else(|| toml_arguments.sub_port.clone().map(Ok))
-			.unwrap_or_else(|| Ok(9933))?,
+			.unwrap_or_else(|| Ok(9944))?,
 		sub_signer: matches.value_of("sub-signer")
 			.map(str::to_owned)
 			.or_else(|| toml_arguments.sub_signer.clone())

--- a/bin/substrate/src/blockchain.rs
+++ b/bin/substrate/src/blockchain.rs
@@ -1,0 +1,360 @@
+// Copyright 2015-2020 Parity Technologies (UK) Ltd.
+// This file is part of Parity Secret Store.
+
+// Parity Secret Store is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity Secret Store is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity Secret Store.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::{
+	collections::BTreeSet,
+	future::Future,
+	ops::Range,
+	pin::Pin,
+	sync::Arc,
+};
+use futures::{
+	FutureExt, Stream, StreamExt,
+	future::{Ready, TryFutureExt, ready},
+};
+use log::error;
+use codec::Encode;
+use primitives::{
+	Address, KeyServerId, ServerKeyId,
+	key_server_set::KeyServerSet,
+	requester::Requester,
+	service::ServiceTask,
+};
+use substrate_service::{
+	Blockchain, BlockchainServiceTask, MaybeSecretStoreEvent,
+};
+use crate::{
+	key_server_set::OnChainKeyServerSet,
+	substrate_client::{BlockRef, Client},
+};
+
+/// Substrate-based blockhain that runs SecretStore module.
+pub struct SecretStoreBlockchain {
+	/// RPC client that can call RPC on full (presumably archive node) that
+	/// is synching the blockhain.
+	client: Client,
+	/// On-chain key server set.
+	key_server_set: Arc<OnChainKeyServerSet>,
+}
+
+/// Substrate runtime event wrapper.
+#[derive(Debug)]
+pub enum SubstrateServiceTaskWrapper {
+	/// Variant for new tasks.
+	Event(crate::runtime::Event),
+	/// Variant for pending tasks.
+	Task(runtime_primitives::service::ServiceTask),
+}
+
+impl SecretStoreBlockchain {
+	/// Create new blockchain.
+	pub fn new(client: Client, key_server_set: Arc<OnChainKeyServerSet>) -> SecretStoreBlockchain {
+		SecretStoreBlockchain {
+			client,
+			key_server_set,
+		}
+	}
+
+	/// Read pending tasks using given method.
+	fn pending_tasks(
+		&self,
+		block_hash: crate::runtime::BlockHash,
+		method: &'static str,
+		range: Range<usize>,
+	) -> impl Stream<Item = SubstrateServiceTaskWrapper> {
+		self.client.call_runtime_method(
+			BlockRef::Hash(block_hash),
+			method,
+			serialize_range(range),
+		).then(|result: Result<Vec<runtime_primitives::service::ServiceTask>, crate::substrate_client::Error>|
+			ready(match result {
+				Ok(tasks) => futures::stream::iter(
+					tasks.into_iter().map(SubstrateServiceTaskWrapper::Task)
+				).boxed(),
+				Err(error) => {
+					error!(
+						target: "secretstore",
+						"Failed to read pending tasks: {:?}",
+						error,
+					);
+
+					futures::stream::empty().boxed()
+				}
+			})
+		).flatten_stream()
+	}
+
+	/// Is response required?
+	fn is_response_required(
+		&self,
+		method: &'static str,
+		arguments: Vec<u8>,
+	) -> impl Future<Output = Result<bool, String>> {
+		self.client.call_runtime_method(
+			BlockRef::RemoteBest,
+			method,
+			arguments,
+		).map_err(|error| format!("{:?}", error))
+	}
+}
+
+impl Blockchain for SecretStoreBlockchain {
+	type BlockHash = crate::runtime::BlockHash;
+	type Event = SubstrateServiceTaskWrapper;
+	type BlockEventsStream = Pin<Box<dyn Stream<Item = Self::Event> + Send>>;
+	type PendingEventsStream = Pin<Box<dyn Stream<Item = Self::Event> + Send>>;
+	type CurrentKeyServersSetFuture = Ready<BTreeSet<KeyServerId>>;
+	type ResponseRequiredFuture = Pin<Box<dyn Future<Output = Result<bool, String>> + Send>>;
+
+	fn block_events(&self, block_hash: Self::BlockHash) -> Self::BlockEventsStream {
+		self.client
+			.header_events(block_hash)
+			.map(move |events| match events {
+				Ok(events) => futures::stream::iter(
+					events.into_iter().map(|event| SubstrateServiceTaskWrapper::Event(event.event))
+				).boxed(),
+				Err(error) => {
+					error!(
+						target: "secretstore",
+						"Failed to read block {} events: {:?}",
+						block_hash,
+						error,
+					);
+
+					futures::stream::empty().boxed()
+				}
+			})
+			.flatten_stream()
+			.boxed()
+	}
+
+	fn current_key_servers_set(&self) -> Self::CurrentKeyServersSetFuture {
+		ready(self.key_server_set.snapshot().current_set.keys().cloned().collect())
+	}
+
+	fn server_key_generation_tasks(
+		&self,
+		block_hash: Self::BlockHash,
+		range: Range<usize>,
+	) -> Self::PendingEventsStream {
+		self.pending_tasks(
+			block_hash,
+			"SecretStoreServiceApi_server_key_generation_tasks",
+			range,
+		).boxed()
+	}
+
+	fn is_server_key_generation_response_required(
+		&self,
+		key_id: ServerKeyId,
+		key_server_id: KeyServerId,
+	) -> Self::ResponseRequiredFuture {
+		self.is_response_required(
+			"SecretStoreServiceApi_is_server_key_generation_response_required",
+			(key_server_id, key_id).encode(),
+		).boxed()
+	}
+
+	fn server_key_retrieval_tasks(
+		&self,
+		block_hash: Self::BlockHash,
+		range: Range<usize>,
+	) -> Self::PendingEventsStream {
+		self.pending_tasks(
+			block_hash,
+			"SecretStoreServiceApi_server_key_retrieval_tasks",
+			range,
+		).boxed()
+	}
+
+	fn is_server_key_retrieval_response_required(
+		&self,
+		key_id: ServerKeyId,
+		key_server_id: KeyServerId,
+	) -> Self::ResponseRequiredFuture {
+		self.is_response_required(
+			"SecretStoreServiceApi_is_server_key_retrieval_response_required",
+			(key_server_id, key_id).encode(),
+		).boxed()
+	}
+
+	fn document_key_store_tasks(
+		&self,
+		block_hash: Self::BlockHash,
+		range: Range<usize>,
+	) -> Self::PendingEventsStream {
+		self.pending_tasks(
+			block_hash,
+			"SecretStoreServiceApi_document_key_store_tasks",
+			range,
+		).boxed()
+	}
+
+	fn is_document_key_store_response_required(
+		&self,
+		key_id: ServerKeyId,
+		key_server_id: KeyServerId,
+	) -> Self::ResponseRequiredFuture {
+		self.is_response_required(
+			"SecretStoreServiceApi_is_document_key_store_response_required",
+			(key_server_id, key_id).encode(),
+		).boxed()
+	}
+
+	fn document_key_shadow_retrieval_tasks(
+		&self,
+		block_hash: Self::BlockHash,
+		range: Range<usize>,
+	) -> Self::PendingEventsStream {
+		self.pending_tasks(
+			block_hash,
+			"SecretStoreServiceApi_document_key_shadow_retrieval_tasks",
+			range,
+		).boxed()
+	}
+
+	fn is_document_key_shadow_retrieval_response_required(
+		&self,
+		key_id: ServerKeyId,
+		requester: Address,
+		key_server_id: KeyServerId,
+	) -> Self::ResponseRequiredFuture {
+		self.is_response_required(
+			"SecretStoreServiceApi_is_document_key_shadow_retrieval_response_required",
+			(key_server_id, key_id, requester).encode(),
+		).boxed()
+	}
+}
+
+impl MaybeSecretStoreEvent for SubstrateServiceTaskWrapper {
+	fn as_secret_store_event(self) -> Option<BlockchainServiceTask> {
+		let origin = Default::default();
+
+		match self {
+			SubstrateServiceTaskWrapper::Event(
+				crate::runtime::Event::secretstore_runtime_module(
+					runtime_module::Event::ServerKeyGenerationRequested(
+						key_id, requester_address, threshold,
+					),
+				)
+			) => Some(BlockchainServiceTask::Regular(
+				origin,
+				ServiceTask::GenerateServerKey(
+					key_id, Requester::Address(requester_address), threshold as usize,
+				)
+			)),
+			SubstrateServiceTaskWrapper::Task(
+				runtime_primitives::service::ServiceTask::GenerateServerKey(
+					key_id, requester_address, threshold,
+				)
+			) => Some(BlockchainServiceTask::Regular(
+				origin,
+				ServiceTask::GenerateServerKey(
+					key_id, Requester::Address(requester_address), threshold as usize,
+				)
+			)),
+			SubstrateServiceTaskWrapper::Event(
+				crate::runtime::Event::secretstore_runtime_module(
+					runtime_module::Event::ServerKeyRetrievalRequested(
+						key_id,
+					),
+				)
+			) => Some(BlockchainServiceTask::Regular(
+				origin,
+				ServiceTask::RetrieveServerKey(
+					key_id, None,
+				)
+			)),
+			SubstrateServiceTaskWrapper::Task(
+				runtime_primitives::service::ServiceTask::RetrieveServerKey(
+					key_id,
+				)
+			) => Some(BlockchainServiceTask::Regular(
+				origin,
+				ServiceTask::RetrieveServerKey(
+					key_id, None,
+				)
+			)),
+			SubstrateServiceTaskWrapper::Event(
+				crate::runtime::Event::secretstore_runtime_module(
+					runtime_module::Event::DocumentKeyStoreRequested(
+						key_id, author, common_point, encrypted_point,
+					),
+				)
+			) => Some(BlockchainServiceTask::Regular(
+				origin,
+				ServiceTask::StoreDocumentKey(
+					key_id, Requester::Address(author), common_point, encrypted_point,
+				)
+			)),
+			SubstrateServiceTaskWrapper::Task(
+				runtime_primitives::service::ServiceTask::StoreDocumentKey(
+					key_id, author, common_point, encrypted_point,
+				)
+			) => Some(BlockchainServiceTask::Regular(
+				origin,
+				ServiceTask::StoreDocumentKey(
+					key_id, Requester::Address(author), common_point, encrypted_point,
+				)
+			)),
+			SubstrateServiceTaskWrapper::Event(
+				crate::runtime::Event::secretstore_runtime_module(
+					runtime_module::Event::DocumentKeyShadowRetrievalRequested(
+						key_id, requester_address,
+					),
+				)
+			) => Some(BlockchainServiceTask::RetrieveShadowDocumentKeyCommon(
+				origin,
+				key_id,
+				Requester::Address(requester_address),
+			)),
+			SubstrateServiceTaskWrapper::Task(
+				runtime_primitives::service::ServiceTask::RetrieveShadowDocumentKeyCommon(
+					key_id, requester_address,
+				)
+			) => Some(BlockchainServiceTask::RetrieveShadowDocumentKeyCommon(
+				origin,
+				key_id,
+				Requester::Address(requester_address),
+			)),
+			SubstrateServiceTaskWrapper::Event(
+				crate::runtime::Event::secretstore_runtime_module(
+					runtime_module::Event::DocumentKeyPersonalRetrievalRequested(
+						key_id, requester_public,
+					),
+				)
+			) => Some(BlockchainServiceTask::RetrieveShadowDocumentKeyPersonal(
+				origin,
+				key_id,
+				Requester::Public(requester_public),
+			)),
+			SubstrateServiceTaskWrapper::Task(
+				runtime_primitives::service::ServiceTask::RetrieveShadowDocumentKeyPersonal(
+					key_id, requester_public,
+				)
+			) => Some(BlockchainServiceTask::RetrieveShadowDocumentKeyPersonal(
+				origin,
+				key_id,
+				Requester::Public(requester_public),
+			)),
+			_ => None,
+		}
+	}
+}
+
+fn serialize_range(range: Range<usize>) -> Vec<u8> {
+	(range.start as u32, range.end as u32).encode()
+}

--- a/bin/substrate/src/cli.yml
+++ b/bin/substrate/src/cli.yml
@@ -31,12 +31,12 @@ args:
     - sub-host:
         long: sub-host
         value_name: SUB_HOST
-        help: Connect to Substrate node at given host.
+        help: Connect to Substrate node at given host. "localhost" by default.
         takes_value: true
     - sub-port:
         long: sub-port
         value_name: SUB_PORT
-        help: Connect to Substrate node at given port.
+        help: Connect to Substrate node at given port. 9944 by default.
         takes_value: true
     - sub-signer:
         long: sub-signer

--- a/bin/substrate/src/cli.yml
+++ b/bin/substrate/src/cli.yml
@@ -1,0 +1,50 @@
+name: parity-secretstore-substrate
+version: "0.1.0"
+author: Parity Technologies <admin@parity.io>
+about: Parity Secret Store for Substrate
+args:
+    - config:
+        long: config
+        value_name: CONFIG
+        help: Path to configuration file.
+        takes_value: true
+    - self-secret:
+        long: self-secret
+        value_name: SELF_SECRET
+        help: Hex-encoded secret key that is used to communicate with other key servers.
+        takes_value: true
+    - db-path:
+        long: db-path
+        value_name: DB_PATH
+        help: Path to key server database where keys shares are stored. By default it points to "db" folder in current directory.
+        takes_value: true
+    - net-host:
+        long: net-host
+        value_name: NET_HOST
+        help: Network interface that key server should use to communicate with other key servers. "0.0.0.0" by default.
+        takes_value: true
+    - net-port:
+        long: net-port
+        value_name: NET_PORT
+        help: Network port (TCP) that key server should use to communicate with other key servers. 8083 by default.
+        takes_value: true
+    - sub-host:
+        long: sub-host
+        value_name: SUB_HOST
+        help: Connect to Substrate node at given host.
+        takes_value: true
+    - sub-port:
+        long: sub-port
+        value_name: SUB_PORT
+        help: Connect to Substrate node at given port.
+        takes_value: true
+    - sub-signer:
+        long: sub-signer
+        value_name: SUB_SIGNER
+        help: The SURI of secret key to use when transactions are submitted to the Substrate node. "//Alice" by default.
+        takes_value: true
+    - sub-signer-password:
+        long: sub-signer-password
+        value_name: SUB_SIGNER_PASSWORD
+        help: The password for the SURI of secret key to use when transactions are submitted to the Substrate node. Empty by default.
+        takes_value: true

--- a/bin/substrate/src/key_server.rs
+++ b/bin/substrate/src/key_server.rs
@@ -1,0 +1,57 @@
+// Copyright 2015-2020 Parity Technologies (UK) Ltd.
+// This file is part of Parity Secret Store.
+
+// Parity Secret Store is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity Secret Store is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity Secret Store.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::sync::Arc;
+use primitives::{
+	error::Error,
+	executor::TokioHandle,
+	key_server_key_pair::KeyServerKeyPair,
+	key_storage::InMemoryKeyStorage,
+};
+use key_server::{ClusterConfiguration, KeyServerImpl};
+use crate::{
+	acl_storage::OnChainAclStorage,
+	key_server_set::OnChainKeyServerSet,
+};
+
+/// Start Secret Store key server.
+pub fn start(
+	executor: TokioHandle,
+	key_server_key_pair: Arc<dyn KeyServerKeyPair>,
+	listen_port: u16,
+	acl_storage: Arc<OnChainAclStorage>,
+	key_server_set: Arc<OnChainKeyServerSet>,
+) -> Result<(Arc<InMemoryKeyStorage>, Arc<KeyServerImpl>), Error> {
+	let key_storage = Arc::new(InMemoryKeyStorage::default());
+	let key_server_config = ClusterConfiguration {
+		admin_address: None,
+		auto_migrate_enabled: true,
+	};
+	key_server::Builder::new()
+		.with_self_key_pair(key_server_key_pair)
+		.with_acl_storage(acl_storage)
+		.with_key_storage(key_storage.clone())
+		.with_config(key_server_config)
+		.build_for_tcp(
+			executor,
+			key_server::network::tcp::NodeAddress {
+				address: "127.0.0.1".into(),
+				port: listen_port,
+			},
+			key_server_set,
+		)
+		.map(|key_server| (key_storage, key_server))
+}

--- a/bin/substrate/src/key_server_set.rs
+++ b/bin/substrate/src/key_server_set.rs
@@ -1,0 +1,262 @@
+// Copyright 2015-2020 Parity Technologies (UK) Ltd.
+// This file is part of Parity Secret Store.
+
+// Parity Secret Store is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity Secret Store is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity Secret Store.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::{
+	collections::BTreeMap,
+	net::SocketAddr,
+	str::FromStr,
+	sync::Arc,
+};
+use futures::FutureExt;
+use log::{error, trace};
+use parking_lot::RwLock;
+use codec::Encode;
+use sp_core::H256;
+use primitives::{
+	KeyServerId,
+	key_server_set::{KeyServerSet, KeyServerSetSnapshot, KeyServerSetMigration, MigrationId},
+};
+use crate::substrate_client::{BlockRef, Client};
+
+/// Number of blocks before the same-migration transaction (be it start or confirmation) will be retried.
+const TRANSACTION_RETRY_INTERVAL_BLOCKS: u32 = 30;
+
+pub struct OnChainKeyServerSet {
+	client: Arc<Client>,
+	self_id: KeyServerId,
+	sync_futures_pool: futures::executor::ThreadPool,
+	data: Arc<RwLock<OnChainKeyServerSetData>>,
+}
+
+struct OnChainKeyServerSetData {
+	best_block_snapshot: KeyServerSetSnapshot<SocketAddr>,
+	/// Previous start migration transaction (if has been sent).
+	start_migration_tx: Option<PreviousMigrationTransaction>,
+	/// Previous confirm migration transaction (if has been sent).
+	confirm_migration_tx: Option<PreviousMigrationTransaction>,
+}
+
+struct PreviousMigrationTransaction {
+	/// ID of migration process.
+	migration_id: MigrationId,
+	/// Best block when transaction has been sent.
+	block: (u32, H256),
+}
+
+impl OnChainKeyServerSet {
+	pub fn new(client: Client, self_id: KeyServerId, sync_futures_pool: futures::executor::ThreadPool) -> Self {
+		OnChainKeyServerSet {
+			client: Arc::new(client),
+			self_id,
+			sync_futures_pool,
+			data: Arc::new(RwLock::new(OnChainKeyServerSetData {
+				best_block_snapshot: KeyServerSetSnapshot {
+					current_set: BTreeMap::new(),
+					new_set: BTreeMap::new(),
+					migration: None,
+				},
+				start_migration_tx: None,
+				confirm_migration_tx: None,
+			})),
+		}
+	}
+
+	pub fn set_best_block(&self, best_block: (crate::runtime::BlockNumber, crate::runtime::BlockHash)) {
+		let data = self.data.clone();
+		let client = self.client.clone();
+		let self_id = self.self_id.encode();
+		let call_runtime_method = async move {
+			client.call_runtime_method(
+				BlockRef::Hash(best_block.1),
+				"SecretStoreKeyServerSetApi_snapshot",
+				self_id,
+			).await
+		};
+
+		self.sync_futures_pool.spawn_ok(
+			call_runtime_method.map(move |result: Result<runtime_primitives::key_server_set::KeyServerSetSnapshot, _>| {
+				match result {
+					Ok(snapshot) => {
+						let snapshot = KeyServerSetSnapshot {
+							current_set: into_socket_addr_set(best_block.1, snapshot.current_set),
+							new_set: into_socket_addr_set(best_block.1, snapshot.new_set),
+							migration: snapshot.migration.map(|migration| KeyServerSetMigration {
+								id: migration.id,
+								set: into_socket_addr_set(best_block.1, migration.set),
+								master: migration.master,
+								is_confirmed: migration.is_confirmed,
+							}),
+						};
+
+						data.write().best_block_snapshot = snapshot;
+					},
+					Err(err) => error!(
+						target: "secretstore",
+						"Failed to read key server set snapshot at {}: {:?}",
+						best_block.1,
+						err,
+					),
+				}
+
+				()
+			})
+		);
+	}
+}
+
+impl KeyServerSet for OnChainKeyServerSet {
+	type NetworkAddress = SocketAddr;
+
+	fn is_isolated(&self) -> bool {
+		!self.data.read().best_block_snapshot.current_set.contains_key(&self.self_id)
+	}
+
+	fn snapshot(&self) -> KeyServerSetSnapshot<SocketAddr> {
+		self.data.read().best_block_snapshot.clone()
+	}
+
+	fn start_migration(&self, migration_id: MigrationId) {
+		{
+			let best_block = self.client.best_block();
+			let mut data = self.data.write();
+			if !update_last_transaction_block(best_block, &migration_id, &mut data.start_migration_tx) {
+				return;
+			}
+		}
+
+		let submit_result = futures::executor::block_on(async {
+			self.client.submit_transaction(crate::runtime::Call::SecretStore(
+				crate::runtime::SecretStoreCall::start_migration(
+					migration_id,
+				),
+			)).await
+		});
+
+		match submit_result {
+			Ok(tx_hash) => trace!(
+				target: "secretstore_net",
+				"{}: Start migration({}) transaction submitted: {:?}",
+				self.self_id,
+				migration_id,
+				tx_hash,
+			),
+			Err(error) => error!(
+				target: "secretstore_net",
+				"{}: Error submitting start migration transaction: {:?}",
+				self.self_id,
+				error,
+			),
+		}
+	}
+
+	fn confirm_migration(&self, migration_id: MigrationId) {
+		{
+			let best_block = self.client.best_block();
+			let mut data = self.data.write();
+			if !update_last_transaction_block(best_block, &migration_id, &mut data.confirm_migration_tx) {
+				return;
+			}
+		}
+
+		let submit_result = futures::executor::block_on(async {
+			self.client.submit_transaction(crate::runtime::Call::SecretStore(
+				crate::runtime::SecretStoreCall::confirm_migration(
+					migration_id,
+				),
+			)).await
+		});
+
+		match submit_result {
+			Ok(tx_hash) => trace!(
+				target: "secretstore_net",
+				"{}: Migration({}) confirmation transaction submitted: {:?}",
+				self.self_id,
+				migration_id,
+				tx_hash,
+			),
+			Err(error) => error!(
+				target: "secretstore_net",
+				"{}: Error submitting confirm migration transaction: {:?}",
+				self.self_id,
+				error,
+			),
+		}
+	}
+}
+
+fn update_last_transaction_block(
+	best_block: (u32, H256),
+	migration_id: &MigrationId,
+	previous_transaction: &mut Option<PreviousMigrationTransaction>,
+) -> bool {
+	match previous_transaction.as_ref() {
+		// no previous transaction => send immediately
+		None => (),
+		// previous transaction has been sent for other migration process => send immediately
+		Some(tx) if tx.migration_id != *migration_id => (),
+		// if we have sent the same type of transaction recently => do nothing (hope it will be mined eventually)
+		// if we have sent the same transaction some time ago =>
+		//   assume that our tx queue was full
+		//   or we didn't have enough eth fot this tx
+		//   or the transaction has been removed from the queue (and never reached any miner node)
+		// if we have restarted after sending tx => assume we have never sent it
+		Some(tx) => {
+			if tx.block.0 > best_block.0 || best_block.0 - tx.block.0 < TRANSACTION_RETRY_INTERVAL_BLOCKS {
+				return false;
+			}
+		},
+	}
+
+	*previous_transaction = Some(PreviousMigrationTransaction {
+		migration_id: migration_id.clone(),
+		block: best_block,
+	});
+
+	true
+}
+
+fn into_socket_addr_set(
+	best_block_hash: H256,
+	map: Vec<(KeyServerId, Vec<u8>)>,
+) -> BTreeMap<KeyServerId, SocketAddr> {
+	map.into_iter()
+		.filter_map(|(server_id, server_address)| {
+			let server_address = parse_socket_addr(server_address);
+			match server_address {
+				Ok(server_address) => Some((server_id, server_address)),
+				Err(err) => {
+					error!(
+						target: "secretstore",
+						"Failed to parse address from server set snapshot at {}: {:?}",
+						best_block_hash,
+						err,
+					);
+
+					None
+				}
+			}
+		})
+		.collect()
+}
+
+fn parse_socket_addr(
+	server_address: Vec<u8>,
+) -> Result<SocketAddr, String> {
+	String::from_utf8(server_address)
+		.map_err(|err| format!("{}", err))
+		.and_then(|addr_str| SocketAddr::from_str(&addr_str)
+			.map_err(|err| format!("{}", err)))
+}

--- a/bin/substrate/src/main.rs
+++ b/bin/substrate/src/main.rs
@@ -1,0 +1,199 @@
+// Copyright 2015-2020 Parity Technologies (UK) Ltd.
+// This file is part of Parity Secret Store.
+
+// Parity Secret Store is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity Secret Store is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity Secret Store.  If not, see <http://www.gnu.org/licenses/>.
+
+#![recursion_limit="256"]
+
+mod acl_storage;
+mod arguments;
+mod blockchain;
+mod key_server;
+mod key_server_set;
+mod runtime;
+mod service;
+mod substrate_client;
+mod transaction_pool;
+
+use std::{
+	io::Write,
+	sync::Arc,
+};
+use futures::FutureExt;
+use log::error;
+use parity_crypto::publickey::{KeyPair, public_to_address};
+use primitives::{
+	executor::{TokioRuntime, tokio_runtime},
+	key_server_key_pair::InMemoryKeyServerKeyPair,
+};
+
+fn main() {
+	initialize();
+
+	let arguments = match arguments::parse_arguments(None) {
+		Ok(arguments) => arguments,
+		Err(error) => {
+			error!(
+				target: "secretstore",
+				"Failed to parse arguments: {:?}",
+				error,
+			);
+
+			return;
+		}
+	};
+
+	let _ = futures::executor::LocalPool::new()
+		.run_until(run_key_server(arguments));
+}
+
+/// Run key server ad blockchain service.
+async fn run_key_server(arguments: arguments::Arguments) -> Result<(), String> {
+	// we still need tokio 0.1 runtime to run SS :/
+	let tokio_runtime = tokio_runtime()
+		.map_err(|err| format!("Error creating tokio runtime: {}", err))?;
+	// and since not everything in SS is async, we need an additional
+	// futures executor that we'll use to run futures in sync functions
+	let thread_pool = futures::executor::ThreadPool::new()
+		.map_err(|err| format!("Error creating thread pool: {}", err))?;
+
+	// start key server and services
+	let (client, key_server_set, best_sender) = start_key_server(
+		arguments,
+		&tokio_runtime,
+		thread_pool,
+	).await?;
+
+	let mut fut_finalized_headers = client.subscribe_finalized_heads().await
+		.map_err(|err| format!("Failed to subscribe to finalized blocks: {:?}", err))?;
+
+	loop {
+		futures::select! {
+			finalized_header = fut_finalized_headers.next().fuse() => {
+				let finalized_block = (finalized_header.number, finalized_header.hash());
+				client.set_best_block(finalized_block);
+				key_server_set.set_best_block(finalized_block);
+				if let Err(error) = best_sender.unbounded_send(finalized_block.1) {
+					error!(
+						target: "secretstore",
+						"Failed to send finalized block: {:?}",
+						error,
+					);
+				}
+			},
+		}
+	}
+}
+
+/// Start key server and blockchain service.
+async fn start_key_server(
+	arguments: arguments::Arguments,
+	tokio_runtime: &TokioRuntime,
+	thread_pool: futures::executor::ThreadPool,
+) -> Result<(
+	substrate_client::Client,
+	Arc<key_server_set::OnChainKeyServerSet>,
+	futures::channel::mpsc::UnboundedSender<runtime::BlockHash>,
+), String> {
+	// let's connect to Substrate node first
+	let client = substrate_client::Client::new(
+		&format!("{}:{}", arguments.sub_host, arguments.sub_port),
+		runtime::create_transaction_signer(
+			&arguments.sub_signer,
+			arguments.sub_signer_password.as_deref(),
+		)?,
+	).await.map_err(|error| format!("Failed to start substrate client: {:?}", error))?;
+
+	// TODO: use db key storage
+
+	// start key server
+	let self_key_pair = KeyPair::from_secret(arguments.self_secret)
+		.map_err(|error| format!("{}", error))?;
+	let self_id = public_to_address(self_key_pair.public());
+	let key_server_key_pair = Arc::new(InMemoryKeyServerKeyPair::new(self_key_pair));
+	let acl_storage = Arc::new(acl_storage::OnChainAclStorage::new(client.clone()));
+	let key_server_set = Arc::new(key_server_set::OnChainKeyServerSet::new(
+		client.clone(),
+		self_id.clone(),
+		thread_pool,
+	));
+	let (key_storage, key_server) = key_server::start(
+		tokio_runtime.executor(),
+		key_server_key_pair.clone(),
+		arguments.net_port,
+		acl_storage.clone(),
+		key_server_set.clone(),
+	).map_err(|error| format!("{:?}", error))?;
+
+	// start substrate service
+	let (best_sender, best_receiver) = futures::channel::mpsc::unbounded();
+	let blockchain = Arc::new(
+		blockchain::SecretStoreBlockchain::new(
+			client.clone(),
+			key_server_set.clone(),
+		)
+	);
+	let transaction_pool = Arc::new(
+		transaction_pool::SecretStoreTransactionPool::new(
+			client.clone(),
+		)
+	);
+	service::start(
+		blockchain,
+		transaction_pool,
+		tokio_runtime.executor(),
+		key_server,
+		key_storage,
+		key_server_key_pair,
+		best_receiver,
+	).map_err(|error| format!("{:?}", error))?;
+
+	Ok((client, key_server_set, best_sender))
+}
+
+fn initialize() {
+	let mut builder = env_logger::Builder::new();
+
+	let filters = match std::env::var("RUST_LOG") {
+		Ok(env_filters) => format!("secretstore=info,secretstore_net=info,{}", env_filters),
+		Err(_) => "secretstore=info,secretstore_net=info".into(),
+	};
+
+	builder.parse_filters(&filters);
+	builder.format(move |buf, record| {
+		writeln!(buf, "{}", {
+			let timestamp = time::strftime("%Y-%m-%d %H:%M:%S %Z", &time::now())
+				.expect("Time is incorrectly formatted");
+			if cfg!(windows) {
+				format!("{} {} {} {}", timestamp, record.level(), record.target(), record.args())
+			} else {
+				use ansi_term::Colour as Color;
+				let log_level = match record.level() {
+					log::Level::Error => Color::Fixed(9).bold().paint(record.level().to_string()),
+					log::Level::Warn => Color::Fixed(11).bold().paint(record.level().to_string()),
+					log::Level::Info => Color::Fixed(10).paint(record.level().to_string()),
+					log::Level::Debug => Color::Fixed(14).paint(record.level().to_string()),
+					log::Level::Trace => Color::Fixed(12).paint(record.level().to_string()),
+				};
+				format!("{} {} {} {}"
+					, Color::Fixed(8).bold().paint(timestamp)
+					, log_level
+					, Color::Fixed(8).paint(record.target())
+					, record.args())
+			}
+		})
+	});
+
+	builder.init();
+}

--- a/bin/substrate/src/runtime.rs
+++ b/bin/substrate/src/runtime.rs
@@ -1,0 +1,109 @@
+// Copyright 2015-2020 Parity Technologies (UK) Ltd.
+// This file is part of Parity Secret Store.
+
+// Parity Secret Store is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity Secret Store is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity Secret Store.  If not, see <http://www.gnu.org/licenses/>.
+
+//! The binary is 'generic' over runtime in its own way - you need to define
+//! runtime types (or aliases) and methods here. Or course after fixing refernces
+//! in Cargo.toml.
+
+use codec::Encode;
+use sp_core::crypto::Pair as _;
+use sp_runtime::traits::{IdentifyAccount, NumberFor};
+
+/// System::events storage key. Calculated as:
+/// twox_128(b"System").to_vec() ++ twox_128(b"Events").to_vec()
+pub const SYSTEM_EVENTS_KEY: &'static str = "26aa394eea5630e07c48ae0c9558cef780d41e5e16056765bc8461851072c9d7";
+
+/// Block hash type.
+pub type BlockHash = substrate_runtime::Hash;
+/// Block number type.
+pub type BlockNumber = NumberFor<substrate_runtime::Block>;
+/// Transaction hash type.
+pub type TransactionHash = substrate_runtime::Hash;
+/// Block header type.
+pub type Header = substrate_runtime::Header;
+/// Block event type.
+pub type Event = substrate_runtime::Event;
+/// Runtime call type.
+pub type Call = substrate_runtime::Call;
+/// Secret Store runtiem call type.
+pub type SecretStoreCall = substrate_runtime::SecretStoreCall<Runtime>;
+/// Runtime itself.
+pub type Runtime = substrate_runtime::Runtime;
+/// Signed payload of the runtime.
+pub type SignedPayload = substrate_runtime::SignedPayload;
+/// Unchecked extrinsic of the runtime.
+pub type UncheckedExtrinsic = substrate_runtime::UncheckedExtrinsic;
+
+/// Account ID of the runtime.
+pub type AccountId = substrate_runtime::AccountId;
+/// Account balance of the runtime.
+pub type Balance = substrate_runtime::Balance;
+/// Account index of the runtime.
+pub type Index = substrate_runtime::Index;
+
+/// Crypto pair that is used to sign transactions.
+pub type Pair = sp_core::sr25519::Pair;
+
+/// Create signer from given SURI and password.
+pub fn create_transaction_signer(
+	signer_uri: &str,
+	signer_password: Option<&str>,
+) -> Result<Pair, String> {
+	Pair::from_string(signer_uri, signer_password)
+		.map_err(|err| format!("Failed to create signer Pair: {:?}", err))
+}
+
+/// Encode and sign runtime transaction.
+pub fn create_transaction(
+	call: Call,
+	signer: &Pair,
+	index: Index,
+	genesis_hash: BlockHash,
+	runtime_version: u32,
+) -> UncheckedExtrinsic {
+	let extra = |i: Index, f: Balance| {
+		(
+			frame_system::CheckVersion::<Runtime>::new(),
+			frame_system::CheckGenesis::<Runtime>::new(),
+			frame_system::CheckEra::<Runtime>::from(sp_runtime::generic::Era::Immortal),
+			frame_system::CheckNonce::<Runtime>::from(i),
+			frame_system::CheckWeight::<Runtime>::new(),
+			pallet_transaction_payment::ChargeTransactionPayment::<Runtime>::from(f),
+		)
+	};
+	let raw_payload = SignedPayload::from_raw(
+		call,
+		extra(index, 0),
+		(
+			runtime_version,
+			genesis_hash,
+			genesis_hash,
+			(),
+			(),
+			(),
+		),
+	);
+	let signature = raw_payload.using_encoded(|payload| signer.sign(payload));
+	let signer: sp_runtime::MultiSigner = signer.public().into();
+	let (function, extra, _) = raw_payload.deconstruct();
+
+	UncheckedExtrinsic::new_signed(
+		function,
+		signer.into_account().into(),
+		signature.into(),
+		extra,
+	)
+}

--- a/bin/substrate/src/service.rs
+++ b/bin/substrate/src/service.rs
@@ -1,0 +1,59 @@
+// Copyright 2015-2020 Parity Technologies (UK) Ltd.
+// This file is part of Parity Secret Store.
+
+// Parity Secret Store is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity Secret Store is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity Secret Store.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::{
+	sync::Arc,
+	time::Duration,
+};
+use futures::Stream;
+use substrate_service::{Configuration, start_service};
+use key_server::KeyServerImpl;
+use primitives::{
+	error::Error,
+	executor::TokioHandle,
+	key_server_key_pair::KeyServerKeyPair,
+	key_storage::InMemoryKeyStorage,
+};
+use crate::{
+	blockchain::SecretStoreBlockchain,
+	transaction_pool::SecretStoreTransactionPool,
+};
+
+pub fn start(
+	blockchain: Arc<SecretStoreBlockchain>,
+	transaction_pool: Arc<SecretStoreTransactionPool>,
+	executor: TokioHandle,
+	key_server: Arc<KeyServerImpl>,
+	key_storage: Arc<InMemoryKeyStorage>,
+	key_server_key_pair: Arc<dyn KeyServerKeyPair>,
+	new_blocks_stream: impl Stream<Item = crate::runtime::BlockHash> + Send + 'static,
+) -> Result<(), Error> {
+	let listener_registrar = key_server.cluster().session_listener_registrar();
+	start_service(
+		key_server,
+		key_storage,
+		listener_registrar,
+		blockchain,
+		Arc::new(executor),
+		transaction_pool,
+		Configuration {
+			self_id: key_server_key_pair.address(),
+			max_active_sessions: Some(4),
+			pending_restart_interval: Some(Duration::from_secs(10 * 60)),
+		},
+		new_blocks_stream,
+	)
+}

--- a/bin/substrate/src/substrate_client.rs
+++ b/bin/substrate/src/substrate_client.rs
@@ -1,0 +1,217 @@
+// Copyright 2015-2020 Parity Technologies (UK) Ltd.
+// This file is part of Parity Secret Store.
+
+// Parity Secret Store is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity Secret Store is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity Secret Store.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::{future::Future, sync::Arc};
+use codec::{Decode, Encode};
+use parking_lot::RwLock;
+use sp_core::crypto::Pair as _;
+use crate::runtime::{
+	SYSTEM_EVENTS_KEY,
+	AccountId, BlockHash, Call, Event, Header,
+	Index, Pair, TransactionHash,
+	create_transaction,
+};
+
+/// All possible errors that can occur during interacting with Substrate node.
+#[derive(Debug)]
+pub enum Error {
+	/// Client creation has failed.
+	ClientCreationFailed(jsonrpsee::transport::ws::WsNewDnsError),
+	/// Request has failed.
+	RequestFailed(jsonrpsee::client::RequestError),
+	/// Response decode has failed.
+	DecodeFailed(codec::Error),
+	/// Failed to get best finalized header.
+	MissingBestFinalizedHeader,
+}
+
+/// Block reference.
+pub enum BlockRef {
+	/// Points at block with given hash.
+	Hash(crate::runtime::BlockHash),
+	/// Points at best block known to use (i.e. best finalized block).
+	/// We use this when we need to deal with the best trusted state of chain
+	/// (i.e. when asking for permissions).
+	LocalBest,
+	/// Points at best block known to Substrate node (i.e. best block of the chain).
+	/// We use this when we need to update chain (i.e. submit transaction).
+	RemoteBest,
+}
+
+/// Substrate client type.
+#[derive(Clone)]
+pub struct Client {
+	/// Substrate RPC client.
+	rpc_client: jsonrpsee::Client,
+	/// Transactions signer.
+	signer: Pair,
+	/// Genesis block hash.
+	genesis_hash: BlockHash,
+	/// Runtime version.
+	runtime_version: u32,
+	/// Best local (finalized) block.
+	best_block: Arc<RwLock<(crate::runtime::BlockNumber, crate::runtime::BlockHash)>>,
+}
+
+impl Client {
+	/// Create new client.
+	pub async fn new(
+		uri: &str,
+		signer: Pair,
+	) -> Result<Self, Error> {
+		let rpc_client = jsonrpsee::ws_client(uri).await.map_err(Error::ClientCreationFailed)?;
+		let genesis_hash = rpc_client.request(
+			"chain_getBlockHash",
+			jsonrpsee::common::Params::Array(vec![
+				serde_json::to_value(0u32).unwrap(),
+			]),
+		).await.map_err(Error::RequestFailed)?;
+		let finalized_hash: crate::runtime::BlockHash = rpc_client.request(
+			"chain_getFinalizedHead",
+			jsonrpsee::common::Params::None,
+		).await.map_err(Error::RequestFailed)?;
+		let finalized_header: Option<crate::runtime::Header> = rpc_client.request(
+			"chain_getHeader",
+			jsonrpsee::common::Params::Array(vec![
+				serde_json::to_value(finalized_hash).unwrap(),
+			]),
+		).await.map_err(Error::RequestFailed)?;
+		let finalized_header = finalized_header.ok_or(Error::MissingBestFinalizedHeader)?;
+		let runtime_version: sp_version::RuntimeVersion = rpc_client.request(
+			"state_getRuntimeVersion",
+			jsonrpsee::common::Params::None,
+		).await.map_err(Error::RequestFailed)?;
+
+		Ok(Client {
+			rpc_client,
+			signer,
+			genesis_hash,
+			runtime_version: runtime_version.spec_version,
+			best_block: Arc::new(RwLock::new((finalized_header.number, finalized_hash))),
+		})
+	}
+
+	/// Update best known block.
+	pub fn set_best_block(&self, best_block: (crate::runtime::BlockNumber, crate::runtime::BlockHash)) {
+		*self.best_block.write() = best_block;
+	}
+
+	/// Return best known block.
+	pub fn best_block(&self) -> (crate::runtime::BlockNumber, crate::runtime::BlockHash) {
+		self.best_block.read().clone()
+	}
+
+	/// Subscribe to new blocks.
+	pub async fn subscribe_finalized_heads(&self) -> Result<jsonrpsee::client::Subscription<Header>, Error> {
+		self.rpc_client.subscribe(
+			"chain_subscribeFinalizedHeads",
+			jsonrpsee::common::Params::None,
+			"chain_unsubscribeFinalizedHeads",
+		).await.map_err(Error::RequestFailed)
+	}
+
+	/// Read events of the header.
+	pub fn header_events(
+		&self,
+		hash: BlockHash,
+	) -> impl Future<Output = Result<Vec<frame_system::EventRecord<Event, BlockHash>>, Error>> {
+		let rpc_client = self.rpc_client.clone();
+		// making fn async doesn't make it return 'static future :/
+		async move {
+			let events_storage: Option<sp_core::Bytes> = rpc_client.clone().request(
+				"state_getStorage",
+				jsonrpsee::common::Params::Array(vec![
+					serde_json::to_value(format!("0x{}", SYSTEM_EVENTS_KEY)).unwrap(),
+					serde_json::to_value(hash).unwrap(),
+				]),
+			).await.map_err(Error::RequestFailed)?;
+			match events_storage {
+				Some(events_storage) => Decode::decode(&mut &events_storage[..])
+					.map_err(Error::DecodeFailed),
+				None => Ok(Vec::new())
+			}
+		}
+	}
+
+	/// Call runtime method.
+	pub fn call_runtime_method<Ret: Decode>(
+		&self,
+		block: BlockRef,
+		method: &'static str,
+		arguments: Vec<u8>,
+	) -> impl Future<Output = Result<Ret, Error>> {
+		let rpc_client = self.rpc_client.clone();
+		let best_block = self.best_block.clone();
+		// making fn async doesn't make it return 'static future :/
+		async move {
+			let arguments = format!("0x{}", hex::encode(arguments));
+			rpc_client.request(
+				"state_call",
+				match block {
+					BlockRef::Hash(hash) => jsonrpsee::common::Params::Array(vec![
+						serde_json::to_value(method).unwrap(),
+						serde_json::to_value(arguments).unwrap(),
+						serde_json::to_value(hash).unwrap(),
+					]),
+					BlockRef::LocalBest => jsonrpsee::common::Params::Array(vec![
+						serde_json::to_value(method).unwrap(),
+						serde_json::to_value(arguments).unwrap(),
+						serde_json::to_value(best_block.read().1).unwrap(),
+					]),
+					BlockRef::RemoteBest => jsonrpsee::common::Params::Array(vec![
+						serde_json::to_value(method).unwrap(),
+						serde_json::to_value(arguments).unwrap(),
+					]),
+				},
+			)
+			.await
+			.map_err(Error::RequestFailed)
+			.and_then(|ret: sp_core::Bytes| Ret::decode(&mut &ret.0[..]).map_err(Error::DecodeFailed))
+		}
+	}
+
+	/// Submit runtime transaction.
+	pub async fn submit_transaction(&self, call: Call) -> Result<TransactionHash, Error> {
+		let index = self.next_account_index().await?;
+		let transaction = create_transaction(
+			call,
+			&self.signer,
+			index,
+			self.genesis_hash,
+			self.runtime_version,
+		);
+		let hex_transaction = format!("0x{}", hex::encode(transaction.encode()));
+		self.rpc_client.request(
+			"author_submitExtrinsic",
+			jsonrpsee::common::Params::Array(vec![
+				serde_json::to_value(hex_transaction).unwrap(),
+			]),
+		).await.map_err(Error::RequestFailed)
+	}
+
+	/// Get substrate account nonce.
+	async fn next_account_index(&self) -> Result<Index, Error> {
+		use sp_core::crypto::Ss58Codec;
+
+		let account_id: AccountId = self.signer.public().as_array_ref().clone().into();
+		self.rpc_client.request(
+			"system_accountNextIndex",
+			jsonrpsee::common::Params::Array(vec![
+				serde_json::to_value(account_id.to_ss58check()).unwrap(),
+			]),
+		).await.map_err(Error::RequestFailed)
+	}
+}

--- a/bin/substrate/src/transaction_pool.rs
+++ b/bin/substrate/src/transaction_pool.rs
@@ -1,0 +1,120 @@
+// Copyright 2015-2020 Parity Technologies (UK) Ltd.
+// This file is part of Parity Secret Store.
+
+// Parity Secret Store is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity Secret Store is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity Secret Store.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::{
+	collections::HashMap,
+	future::Future,
+	pin::Pin,
+};
+use futures::{FutureExt, TryFutureExt};
+use primitives::KeyServerId;
+use substrate_service::{TransactionPool, SecretStoreCall};
+use crate::{
+	runtime::TransactionHash,
+	substrate_client::{BlockRef, Client},
+};
+
+/// Transaction pool of Substrate node that runs blockchain with Secret Store module.
+pub struct SecretStoreTransactionPool {
+	client: Client,
+}
+
+impl SecretStoreTransactionPool {
+	/// Create new transaction pool.
+	pub fn new(client: Client) -> SecretStoreTransactionPool {
+		SecretStoreTransactionPool { client }
+	}
+}
+
+impl TransactionPool for SecretStoreTransactionPool {
+	type TransactionHash = TransactionHash;
+	type SubmitTransactionFuture = Pin<Box<dyn Future<Output = Result<Self::TransactionHash, String>> + Send>>;
+
+	fn submit_transaction(&self, call: SecretStoreCall) -> Self::SubmitTransactionFuture {
+		let client = self.client.clone();
+		async move {
+			client.submit_transaction(crate::runtime::Call::SecretStore(
+				match call {
+					SecretStoreCall::ServerKeyGenerated(key_id, key) =>
+						crate::runtime::SecretStoreCall::server_key_generated(
+							key_id,
+							key,
+						),
+					SecretStoreCall::ServerKeyGenerationError(key_id) =>
+						crate::runtime::SecretStoreCall::server_key_generation_error(
+							key_id,
+						),
+					SecretStoreCall::ServerKeyRetrieved(key_id, key, threshold) =>
+						crate::runtime::SecretStoreCall::server_key_retrieved(
+							key_id,
+							key,
+							threshold,
+						),
+					SecretStoreCall::ServerKeyRetrievalError(key_id) =>
+						crate::runtime::SecretStoreCall::server_key_retrieval_error(
+							key_id,
+						),
+					SecretStoreCall::DocumentKeyStored(key_id) =>
+						crate::runtime::SecretStoreCall::document_key_stored(
+							key_id,
+						),
+					SecretStoreCall::DocumentKeyStoreError(key_id) =>
+						crate::runtime::SecretStoreCall::document_key_store_error(
+							key_id,
+						),
+					SecretStoreCall::DocumentKeyCommonRetrieved(key_id, requester, common_point, threshold) =>
+						crate::runtime::SecretStoreCall::document_key_common_retrieved(
+							key_id,
+							requester,
+							common_point,
+							threshold,
+						),
+					SecretStoreCall::DocumentKeyPersonalRetrieved(key_id, requester, participants, decrypted_secret, shadow) => {
+						// we're checking confirmation in Latest block, because tx is applied to the latest state
+						let current_set_with_indices: Vec<(KeyServerId, u8)> = futures::executor::block_on(async {
+							client.call_runtime_method(
+								BlockRef::RemoteBest,
+								"SecretStoreKeyServerSetApi_current_set_with_indices",
+								Vec::new(),
+							).await
+						}).map_err(|err| format!("{:?}", err))?;
+						let current_set_with_indices = current_set_with_indices.into_iter().collect::<HashMap<_, _>>();
+
+						let mut participants_mask = runtime_primitives::KeyServersMask::default();
+						for participant in participants {
+							let index = current_set_with_indices.get(&participant)
+								.ok_or_else(|| format!("Missing index for key server {}", participant))?;
+							participants_mask = participants_mask.union(runtime_primitives::KeyServersMask::from_index(*index));
+						}
+
+						crate::runtime::SecretStoreCall::document_key_personal_retrieved(
+							key_id,
+							requester,
+							participants_mask,
+							decrypted_secret,
+							shadow,
+						)
+					},
+					SecretStoreCall::DocumentKeyShadowRetrievalError(key_id, requester) =>
+						crate::runtime::SecretStoreCall::document_key_shadow_retrieval_error(
+							key_id,
+							requester,
+						),
+				}
+			)).map_err(|err| format!("{:?}", err)).await
+		}.boxed()
+	}
+}

--- a/key-server/Cargo.toml
+++ b/key-server/Cargo.toml
@@ -15,7 +15,7 @@ keccak-hash = "0.4.0"
 lazy_static = "1.0"
 libsecp256k1 = { version = "0.3.5", default-features = false }
 log = "0.4"
-parity-crypto = { version = "0.5.0", features = ["publickey"] }
+parity-crypto = { version = "0.5", features = ["publickey"] }
 parking_lot = "0.10.0"
 serde = "1.0"
 serde_json = "1.0"

--- a/substrate-runtime/runtime/Cargo.toml
+++ b/substrate-runtime/runtime/Cargo.toml
@@ -10,6 +10,7 @@ serde = { version = "1.0.101", optional = true, features = ["derive"] }
 frame-executive = { version = "2.0.0-alpha.3", default-features = false }
 frame-support = { version = "2.0.0-alpha.3", default-features = false }
 frame-system = { version = "2.0.0-alpha.3", default-features = false }
+frame-system-rpc-runtime-api = { version = "2.0.0-alpha.3", default-features = false }
 pallet-aura = { version = "2.0.0-alpha.3", default-features = false }
 pallet-balances = { version = "2.0.0-alpha.3", default-features = false }
 pallet-grandpa = { version = "2.0.0-alpha.3", default-features = false }
@@ -42,6 +43,7 @@ std = [
 	"frame-executive/std",
 	"frame-support/std",
 	"frame-system/std",
+	"frame-system-rpc-runtime-api/std",
 	"pallet-aura/std",
 	"pallet-balances/std",
 	"pallet-grandpa/std",

--- a/substrate-runtime/runtime/src/lib.rs
+++ b/substrate-runtime/runtime/src/lib.rs
@@ -376,6 +376,12 @@ impl_runtime_apis! {
 		}
 	}
 
+	impl frame_system_rpc_runtime_api::AccountNonceApi<Block, AccountId, Index> for Runtime {
+		fn account_nonce(account: AccountId) -> Index {
+			System::account_nonce(account)
+		}
+	}
+
 	impl secretstore_runtime_primitives::acl_storage::SecretStoreAclApi<Block> for Runtime {
 		fn check(
 			_requester: secretstore_runtime_primitives::EntityId,

--- a/substrate-runtime/runtime/src/lib.rs
+++ b/substrate-runtime/runtime/src/lib.rs
@@ -277,6 +277,8 @@ pub type SignedExtra = (
 	frame_system::CheckWeight<Runtime>,
 	pallet_transaction_payment::ChargeTransactionPayment<Runtime>
 );
+/// The payload being signed in transactions.
+pub type SignedPayload = generic::SignedPayload<Call, SignedExtra>;
 /// Unchecked extrinsic type as expected by this runtime.
 pub type UncheckedExtrinsic = generic::UncheckedExtrinsic<Address, Call, Signature, SignedExtra>;
 /// Extrinsic type that has already been checked.


### PR DESCRIPTION
This PR introduces first SS binary in this repo: `parity-secretstore-substrate`. It starts key server, substrate service and connects to Substrate node that run blockchain with SecretStore module. Since there could be multiple different blockchains which use different hashes, transactions, etc, this binary is designed to be 'generic' (not as in Rust) over runtime. Everything must be configured in the `runtime.rs` module. The node should also expose `system_accountNextIndex` RPC. Right now it is configured to work with the `bin/substrate-node`.

Tests are yet to be added - both integration (#17 ) and module-level.