### PR TITLE
Added client subcommands to SS-for-Substrate binary

### DIFF
--- a/bin/substrate/Cargo.toml
+++ b/bin/substrate/Cargo.toml
@@ -18,6 +18,7 @@ jsonrpsee = { git = "https://github.com/paritytech/jsonrpsee.git", features = ["
 log = "0.4"
 parity-crypto = { version = "0.5", features = ["publickey"] }
 parking_lot = "0.9"
+rand = "0.7"
 regex = "1.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_with = "1.4"

--- a/bin/substrate/Cargo.toml
+++ b/bin/substrate/Cargo.toml
@@ -18,6 +18,7 @@ jsonrpsee = { git = "https://github.com/paritytech/jsonrpsee.git", features = ["
 log = "0.4"
 parity-crypto = { version = "0.5", features = ["publickey"] }
 parking_lot = "0.9"
+regex = "1.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_with = "1.4"
 serde_json = "1.0"
@@ -30,6 +31,7 @@ frame-system = "2.0.0-alpha.3"
 pallet-transaction-payment = "2.0.0-alpha.3"
 sp-core = "2.0.0-alpha.3"
 sp-runtime = "2.0.0-alpha.3"
+sp-transaction-pool = "2.0.0-alpha.3"
 sp-version = "2.0.0-alpha.3"
 
 # internal secret store references

--- a/bin/substrate/README.md
+++ b/bin/substrate/README.md
@@ -2,7 +2,7 @@
 
 More docs will be added later...
 
-## Quick start
+## Quick start: running key servers
 
 ```bash
 #!/bin/bash
@@ -25,4 +25,71 @@ RUST_LOG=secretstore=trace,secretstore_net=trace unbuffer ./parity-secretstore-s
 RUST_LOG=secretstore=trace,secretstore_net=trace unbuffer ./parity-secretstore-substrate --self-secret=0202020202020202020202020202020202020202020202020202020202020202 --db-path=ssdb.2 --net-port=10001 --sub-signer=//Bob 2>&1 | unbuffer -p gawk '{ print strftime("Bob: [%Y-%m-%d %H:%M:%S]"), $0 }' | unbuffer -p tee ssbob.log&
 RUST_LOG=secretstore=trace,secretstore_net=trace unbuffer ./parity-secretstore-substrate --self-secret=0303030303030303030303030303030303030303030303030303030303030303 --db-path=ssdb.3 --net-port=10002 --sub-signer=//Charlie 2>&1 | unbuffer -p gawk '{ print strftime("Charlie: [%Y-%m-%d %H:%M:%S]"), $0 }' | unbuffer -p tee sscharlie.log&
 RUST_LOG=secretstore=trace,secretstore_net=trace unbuffer ./parity-secretstore-substrate --self-secret=0404040404040404040404040404040404040404040404040404040404040404 --db-path=ssdb.4 --net-port=10003 --sub-signer=//Dave 2>&1 | unbuffer -p gawk '{ print strftime("Dave: [%Y-%m-%d %H:%M:%S]"), $0 }' | unbuffer -p tee ssdave.log&
+```
+
+## Quick start: generating, storing and retrieving keys
+
+```bash
+# //Alice claims 'ownership' of key 0x0101010101010101010101010101010101010101010101010101010101010101
+./parity-secretstore-substrate submit-transaction --wait-processed --transaction="ClaimKey(0x0101010101010101010101010101010101010101010101010101010101010101)"
+2020-03-27 12:33:36  INFO secretstore Transaction has been accepted to Ready queue
+2020-03-27 12:33:42  INFO secretstore Transaction is mined in block: 0x84cd4b2433546d146b33968f66989f2dc2916a04d973e3e82ebbf7d015394b18
+
+# //Alice asks to generate server key 0x0101010101010101010101010101010101010101010101010101010101010101
+# with threshold = 1
+./parity-secretstore-substrate submit-transaction --wait-processed --transaction="GenerateServerKey(0101010101010101010101010101010101010101010101010101010101010101, 1)"
+2020-03-27 12:34:00  INFO secretstore Transaction has been accepted to Ready queue
+2020-03-27 12:34:06  INFO secretstore Transaction is mined in block: 0xf472aefc1436c5d687876f3c4a563a08af042badef4a5371787645a470669b33
+2020-03-27 12:34:19  INFO secretstore Transaction block is finalized: 0xf472aefc1436c5d687876f3c4a563a08af042badef4a5371787645a470669b33
+2020-03-27 12:34:24  INFO secretstore Server key has been generated: 0x126e2601cdb257e089685a5ab9978c417cf7e75b0d45d9c07c00fdacb4b00f58196717456eaf3bf1d3edfa776d035a469542668c0bbd78817e1dfae80ecaa434
+
+# //Alice generates document key (offline operation).
+#
+# Single key is generated, but it comes in two forms:
+# 1) common and encrypted point is the input data for StoreDocumentKey transaction;
+# 2) encrypted key could be used to encrypt arbitrary message locally.
+./parity-secretstore-substrate generate-document-key --server-key=0x126e2601cdb257e089685a5ab9978c417cf7e75b0d45d9c07c00fdacb4b00f58196717456eaf3bf1d3edfa776d035a469542668c0bbd78817e1dfae80ecaa434 --author-key=0x1b84c5567b126440995d3ed5aaba0565d71e1834604819ff9c17f5e9d5dd078f70beaf8f588b541507fed6a642c5ab42dfdf8120a7f639de5122d47a69a8e8d1
+2020-03-27 12:35:11  INFO secretstore Common point: 0x12e20fd9ab6697e120a47ff1f278d3c85ef20d7044f6bcc780801c5bc2ee1be574dd69772ebab548ddddc6e901cbc2a5362e3fb920367898ab8749d09297a1ee
+2020-03-27 12:35:11  INFO secretstore Encrypted point: 0x6e21608df33c8927abc756a8f7c71998728bf4be0ae0f09b1780ac6a4c83f86251a710d29b3cfe17129f0a5612c5f2b0fb9a2fb20011dab3623a86460b58d80b
+2020-03-27 12:35:11  INFO secretstore Encrypted key: 0x0417cabe0bd7df0a8f1034d5fe99e8ce7ef81e5802acdb33ef977b2812a9f0cac5d8fd9cc534d75bb6079f56d6b6392ef8b73abfaf636eec54bebd5ac1ae6ae2457cff98454326d6ec711da12fc08c4dbf9f3565d8254aa9f89c8f94685d322cc1babca189cebe624ba3e8b3cc8bc2b46a979fcf5b2995a2de148d9e4cf15ff79b7eb2ed1e7d7aa1ccc4929676c114f4df39687c9a4bd44bc3c6f4e1a23a718113ccc4d1a2fde29e5a625322db642f573c
+
+# //Alice encrypts message (offline operation).
+#
+# Encrypted message can now be shared, but only //Alice has access to the key.
+./parity-secretstore-substrate encrypt-message --encrypted-document-key=0x0417cabe0bd7df0a8f1034d5fe99e8ce7ef81e5802acdb33ef977b2812a9f0cac5d8fd9cc534d75bb6079f56d6b6392ef8b73abfaf636eec54bebd5ac1ae6ae2457cff98454326d6ec711da12fc08c4dbf9f3565d8254aa9f89c8f94685d322cc1babca189cebe624ba3e8b3cc8bc2b46a979fcf5b2995a2de148d9e4cf15ff79b7eb2ed1e7d7aa1ccc4929676c114f4df39687c9a4bd44bc3c6f4e1a23a718113ccc4d1a2fde29e5a625322db642f573c --author-secret=0x0101010101010101010101010101010101010101010101010101010101010101 --message="Hello, world!"
+2020-03-27 12:39:44  INFO secretstore Encrypted message: 0x61a0328d8735d1fd0b2230d78b07a7f364a361c5bd11ecb8d485771af2
+
+# //Alice just checks that (local) decryption works (offline operation).
+./parity-secretstore-substrate decrypt-message --encrypted-document-key=0x0417cabe0bd7df0a8f1034d5fe99e8ce7ef81e5802acdb33ef977b2812a9f0cac5d8fd9cc534d75bb6079f56d6b6392ef8b73abfaf636eec54bebd5ac1ae6ae2457cff98454326d6ec711da12fc08c4dbf9f3565d8254aa9f89c8f94685d322cc1babca189cebe624ba3e8b3cc8bc2b46a979fcf5b2995a2de148d9e4cf15ff79b7eb2ed1e7d7aa1ccc4929676c114f4df39687c9a4bd44bc3c6f4e1a23a718113ccc4d1a2fde29e5a625322db642f573c --requester-secret=0x0101010101010101010101010101010101010101010101010101010101010101 --encrypted-message=0x61a0328d8735d1fd0b2230d78b07a7f364a361c5bd11ecb8d485771af2
+2020-03-27 12:40:03  INFO secretstore Decrypted message: "Hello, world!"
+
+# //Alice asks Secret Store to store generated document key.
+./parity-secretstore-substrate submit-transaction --wait-processed --transaction="StoreDocumentKey(0101010101010101010101010101010101010101010101010101010101010101, 0x12e20fd9ab6697e120a47ff1f278d3c85ef20d7044f6bcc780801c5bc2ee1be574dd69772ebab548ddddc6e901cbc2a5362e3fb920367898ab8749d09297a1ee, 0x6e21608df33c8927abc756a8f7c71998728bf4be0ae0f09b1780ac6a4c83f86251a710d29b3cfe17129f0a5612c5f2b0fb9a2fb20011dab3623a86460b58d80b)"
+2020-03-27 12:41:07  INFO secretstore Transaction has been accepted to Ready queue
+2020-03-27 12:41:12  INFO secretstore Transaction is mined in block: 0x8268317c5d62efdc8eed5ccdf7f4a7dc7fbeaca8a8635f346f95cdded2a95769
+2020-03-27 12:41:25  INFO secretstore Transaction block is finalized: 0x8268317c5d62efdc8eed5ccdf7f4a7dc7fbeaca8a8635f346f95cdded2a95769
+2020-03-27 12:41:30  INFO secretstore Document key has been stored
+
+# //Alice asks Secret Store to retrieve document key shadow.
+./parity-secretstore-substrate submit-transaction --wait-processed --transaction="RetrieveDocumentKeyShadow(0101010101010101010101010101010101010101010101010101010101010101, 0x1b84c5567b126440995d3ed5aaba0565d71e1834604819ff9c17f5e9d5dd078f70beaf8f588b541507fed6a642c5ab42dfdf8120a7f639de5122d47a69a8e8d1)"
+020-03-27 12:42:15  INFO secretstore Transaction has been accepted to Ready queue
+2020-03-27 12:42:18  INFO secretstore Transaction is mined in block: 0xc3d386552029be0dd8e7f262f8525f0bf6c39d656ddc5455f5356dfe8284cf02
+2020-03-27 12:42:31  INFO secretstore Transaction block is finalized: 0xc3d386552029be0dd8e7f262f8525f0bf6c39d656ddc5455f5356dfe8284cf02
+2020-03-27 12:42:36  INFO secretstore Common portion of document key has been retrieved: threshold = 1, common_point = 0x12e20fd9ab6697e120a47ff1f278d3c85ef20d7044f6bcc780801c5bc2ee1be58b229688d1454ab722223916fe343d5ac9d1c046dfc987675478b62e6d685a41
+2020-03-27 12:42:54  INFO secretstore Adding new personal entry candidate: 0xb8a7bbf1894c3a7991273818c1381dbf48132c6b92442caa4dc40f6a86dd39068ecfd4f385e94a49494bf101d18bf5e79b433629467a3bd383f160d8193509ba
+2020-03-27 12:42:54  INFO secretstore Received shadow for personal entry: 0xb8a7bbf1894c3a7991273818c1381dbf48132c6b92442caa4dc40f6a86dd39068ecfd4f385e94a49494bf101d18bf5e79b433629467a3bd383f160d8193509ba. 1 More required
+2020-03-27 12:42:54  INFO secretstore Received last required shadow for personal entry: 0xb8a7bbf1894c3a7991273818c1381dbf48132c6b92442caa4dc40f6a86dd39068ecfd4f385e94a49494bf101d18bf5e79b433629467a3bd383f160d8193509ba
+2020-03-27 12:42:54  INFO secretstore Final shadows list: ["0x04195e1c00655d2828ee5fcf709f60ab430f0280d61954c201fb6a3038636bd78357ddcce876718c1a6b438c81edfde567f77cf54ddf3aa6f1a93e16d54259da713d756e581976c21e5acba3b887c0a0b73fd27ff75468fc1818257550b6b6c6e95bb3fe33ab94bbbdd4c28823c63f5be18b2c23c071142789875c61cf04cfac712d20f414ee5b1578fc0766cc10a33cf6", "0x0440ca8a95106281a2e3bbf4b6d34033f4951371f99b85db08e2b838e9ab6e78997643196e640981d6e7b662267e0847aca461d09f7711b249bc31ac72e21784f84eb7f5a9fd4359dd298a9d2272463a6c35c071d8a9a27bf5dc0ec63cd8f60fb18653c5cc1ab92c8037b74fb78dec2a4ddb581b0c6839a9f4c36e9ca18bf8c0d6e749a0e201cde5fb5f5fa587f0d2efd5"]
+
+# //Alice just checks that decryption works (offline operation).
+./parity-secretstore-substrate shadow-decrypt-message --common-point=0x12e20fd9ab6697e120a47ff1f278d3c85ef20d7044f6bcc780801c5bc2ee1be58b229688d1454ab722223916fe343d5ac9d1c046dfc987675478b62e6d685a41 --decrypted-secret=0xb8a7bbf1894c3a7991273818c1381dbf48132c6b92442caa4dc40f6a86dd39068ecfd4f385e94a49494bf101d18bf5e79b433629467a3bd383f160d8193509ba --decrypt-shadows=0x04195e1c00655d2828ee5fcf709f60ab430f0280d61954c201fb6a3038636bd78357ddcce876718c1a6b438c81edfde567f77cf54ddf3aa6f1a93e16d54259da713d756e581976c21e5acba3b887c0a0b73fd27ff75468fc1818257550b6b6c6e95bb3fe33ab94bbbdd4c28823c63f5be18b2c23c071142789875c61cf04cfac712d20f414ee5b1578fc0766cc10a33cf6 --decrypt-shadows=0x0440ca8a95106281a2e3bbf4b6d34033f4951371f99b85db08e2b838e9ab6e78997643196e640981d6e7b662267e0847aca461d09f7711b249bc31ac72e21784f84eb7f5a9fd4359dd298a9d2272463a6c35c071d8a9a27bf5dc0ec63cd8f60fb18653c5cc1ab92c8037b74fb78dec2a4ddb581b0c6839a9f4c36e9ca18bf8c0d6e749a0e201cde5fb5f5fa587f0d2efd5 --requester-secret=0x0101010101010101010101010101010101010101010101010101010101010101 --encrypted-message=0x61a0328d8735d1fd0b2230d78b07a7f364a361c5bd11ecb8d485771af2
+2020-03-27 12:44:45  INFO secretstore Decrypted message: "Hello, world!"
+
+# //Alice transfers key ownership to //Bob.
+#
+# This means that //Alice now can't recover key and //Bob can.
+# (note that in our case //Alice still knows the document key, because she has generated it)
+./parity-secretstore-substrate submit-transaction --wait-processed --transaction="TransferKey(0x0101010101010101010101010101010101010101010101010101010101010101, 0x5050a4f4b3f9338c3472dcc01a87c76a144b3c9c)"
+2020-03-27 12:49:08  INFO secretstore Transaction has been accepted to Ready queue
+2020-03-27 12:49:12  INFO secretstore Transaction is mined in block: 0x76d8685136af8096264ac98fa85c0fd2f3f8840a191af3441d2b9ed4c2c50ed8
 ```

--- a/bin/substrate/src/arguments.rs
+++ b/bin/substrate/src/arguments.rs
@@ -15,6 +15,7 @@
 // along with Parity Secret Store.  If not, see <http://www.gnu.org/licenses/>.
 
 use std::str::FromStr;
+use clap::ArgMatches;
 use serde::Deserialize;
 use parity_crypto::publickey::Secret;
 
@@ -72,15 +73,8 @@ mod opt_secret {
 
 /// Parse command line arguments.
 pub fn parse_arguments<'a>(
-	args: Option<Vec<&'a str>>,
+	matches: &ArgMatches,
 ) -> Result<Arguments, String> {
-	let yaml = clap::load_yaml!("cli.yml");
-	let clap_app = clap::App::from_yaml(yaml);
-	let matches = match args {
-		Some(args) => clap_app.get_matches_from(args),
-		None => clap_app.get_matches(),
-	};
-
 	let toml_arguments: TomlArguments = match matches.value_of("config") {
 		Some(config_file_path) => std::fs::read_to_string(config_file_path)
 			.map_err(|err| format!("{}", err))
@@ -132,8 +126,10 @@ mod tests {
 
 	#[test]
 	fn arguments_read_some_from_cli() {
+		let yaml = clap::load_yaml!("cli.yml");
+		let clap_app = clap::App::from_yaml(yaml);
 		assert_eq!(
-			parse_arguments(Some(vec![
+			parse_arguments(&clap_app.get_matches_from(vec![
 				"parity-secretstore-substrate",
 				"--self-secret=0101010101010101010101010101010101010101010101010101010101010101",
 				"--net-host=nethost.com",
@@ -155,8 +151,10 @@ mod tests {
 
 	#[test]
 	fn arguments_read_full_from_cli() {
+		let yaml = clap::load_yaml!("cli.yml");
+		let clap_app = clap::App::from_yaml(yaml);
 		assert_eq!(
-			parse_arguments(Some(vec![
+			parse_arguments(&clap_app.get_matches_from(vec![
 				"parity-secretstore-substrate",
 				"--self-secret=0101010101010101010101010101010101010101010101010101010101010101",
 				"--db-path=mydb",
@@ -182,6 +180,8 @@ mod tests {
 
 	#[test]
 	fn arguments_read_some_from_file() {
+		let yaml = clap::load_yaml!("cli.yml");
+		let clap_app = clap::App::from_yaml(yaml);
 		let temp_dir = tempdir::TempDir::new("arguments_read_from_file").unwrap();
 		let temp_file_path = temp_dir.path().join("config.toml");
 		std::fs::File::create(temp_file_path.clone()).unwrap().write_all(r#"
@@ -191,7 +191,7 @@ sub-signer = "//Bob"
 		"#.as_bytes()).unwrap();
 
 		assert_eq!(
-			parse_arguments(Some(vec![
+			parse_arguments(&clap_app.get_matches_from(vec![
 				"parity-secretstore-substrate",
 				"--config",
 				temp_file_path.to_str().unwrap(),
@@ -213,6 +213,8 @@ sub-signer = "//Bob"
 
 	#[test]
 	fn arguments_read_full_from_file() {
+		let yaml = clap::load_yaml!("cli.yml");
+		let clap_app = clap::App::from_yaml(yaml);
 		let temp_dir = tempdir::TempDir::new("arguments_read_from_file").unwrap();
 		let temp_file_path = temp_dir.path().join("config.toml");
 		std::fs::File::create(temp_file_path.clone()).unwrap().write_all(r#"
@@ -227,7 +229,7 @@ sub-signer-password = "password"
 		"#.as_bytes()).unwrap();
 
 		assert_eq!(
-			parse_arguments(Some(vec![
+			parse_arguments(&clap_app.get_matches_from(vec![
 				"parity-secretstore-substrate",
 				"--config",
 				temp_file_path.to_str().unwrap(),
@@ -247,6 +249,8 @@ sub-signer-password = "password"
 
 	#[test]
 	fn arguments_from_cli_overrides_arguments_from_file() {
+		let yaml = clap::load_yaml!("cli.yml");
+		let clap_app = clap::App::from_yaml(yaml);
 		let temp_dir = tempdir::TempDir::new("arguments_read_from_file").unwrap();
 		let temp_file_path = temp_dir.path().join("config.toml");
 		std::fs::File::create(temp_file_path.clone()).unwrap().write_all(r#"
@@ -254,7 +258,7 @@ self-secret = "0202020202020202020202020202020202020202020202020202020202020202"
 		"#.as_bytes()).unwrap();
 
 		assert_eq!(
-			parse_arguments(Some(vec![
+			parse_arguments(&clap_app.get_matches_from(vec![
 				"parity-secretstore-substrate",
 				"--config",
 				temp_file_path.to_str().unwrap(),

--- a/bin/substrate/src/cli.yml
+++ b/bin/substrate/src/cli.yml
@@ -48,3 +48,44 @@ args:
         value_name: SUB_SIGNER_PASSWORD
         help: The password for the SURI of secret key to use when transactions are submitted to the Substrate node. Empty by default.
         takes_value: true
+subcommands:
+    - sub-submit:
+        about: Submit SS-related Substrate transaction.
+        args:
+            - sign-secret:
+                long: self-secret
+                value_name: SELF_SECRET
+                help: Hex-encoded secret key that is used to sign .
+                takes_value: true
+            - sub-host:
+                long: sub-host
+                value_name: SUB_HOST
+                help: Connect to Substrate node at given host. "localhost" by default.
+                takes_value: true
+            - sub-port:
+                long: sub-port
+                value_name: SUB_PORT
+                help: Connect to Substrate node at given port. 9944 by default.
+                takes_value: true
+            - sub-signer:
+                long: sub-signer
+                value_name: SUB_SIGNER
+                help: The SURI of secret key to use when transactions are submitted to the Substrate node. "//Alice" by default.
+                takes_value: true
+            - sub-signer-password:
+                long: sub-signer-password
+                value_name: SUB_SIGNER_PASSWORD
+                help: The password for the SURI of secret key to use when transactions are submitted to the Substrate node. Empty by default.
+                takes_value: true
+            - sub-call:
+                long: sub-call
+                value_name: SUB_CALL
+                help: Substrate call. Refer to SecretStoreTransaction enum for details.
+                takes_value: true
+                required: true
+            - wait:
+                long: wait
+                help: Wait until transaction is included in the block.
+            - wait-results:
+                long: wait-results
+                help: Wait until transaction is included in the block and it is processed by the Secret Store (if available).

--- a/bin/substrate/src/cli.yml
+++ b/bin/substrate/src/cli.yml
@@ -49,14 +49,9 @@ args:
         help: The password for the SURI of secret key to use when transactions are submitted to the Substrate node. Empty by default.
         takes_value: true
 subcommands:
-    - sub-submit:
-        about: Submit SS-related Substrate transaction.
+    - submit-transaction:
+        about: Submit Substrate transaction.
         args:
-            - sign-secret:
-                long: self-secret
-                value_name: SELF_SECRET
-                help: Hex-encoded secret key that is used to sign .
-                takes_value: true
             - sub-host:
                 long: sub-host
                 value_name: SUB_HOST
@@ -77,15 +72,112 @@ subcommands:
                 value_name: SUB_SIGNER_PASSWORD
                 help: The password for the SURI of secret key to use when transactions are submitted to the Substrate node. Empty by default.
                 takes_value: true
-            - sub-call:
-                long: sub-call
-                value_name: SUB_CALL
-                help: Substrate call. Refer to SecretStoreTransaction enum for details.
+            - transaction:
+                long: transaction
+                value_name: TRANSACTION
+                help: Transaction to be submitted. Refer to SecretStoreTransaction enum for details.
                 takes_value: true
                 required: true
-            - wait:
-                long: wait
+            - wait-mined:
+                long: wait-mined
                 help: Wait until transaction is included in the block.
-            - wait-results:
-                long: wait-results
-                help: Wait until transaction is included in the block and it is processed by the Secret Store (if available).
+            - wait-finalized:
+                long: wait-finalized
+                help: Wait until block with transaction is finalized. Assumes wait-mined.
+            - wait-processed:
+                long: wait-processed
+                help: Wait until transaction is processed by SecretStore (if applicable). Assumes wait-finalized.
+    - generate-key-pair:
+        about: Generate key pair.
+    - generate-document-key:
+        about: Generate document key.
+        args:
+            - server-key:
+                long: server-key
+                value_name: SERVER_KEY
+                help: Hex-encoded server public key.
+                takes_value: true
+                required: true
+            - author-key:
+                long: author-key
+                value_name: AUTHOR_KEY
+                help: Hex-encoded author public key.
+                takes_value: true
+                required: true
+    - encrypt-message:
+        about: Encrypt message using encrypted document key.
+        args:
+            - encrypted-document-key:
+                long: encrypted-document-key
+                value_name: ENCRYPTED_DOCUMENT_KEY
+                help: Hex-encoded encrypted document key.
+                takes_value: true
+                required: true
+            - author-secret:
+                long: author-secret
+                value_name: AUTHOR_SECRET
+                help: Hex-encoded author secret key.
+                takes_value: true
+                required: true
+            - message:
+                long: message
+                value_name: MESSAGE
+                help: Arbitrary message string.
+                takes_value: true
+                required: true
+    - decrypt-message:
+        about: Decrypt message using encrypted document key.
+        args:
+            - encrypted-document-key:
+                long: encrypted-document-key
+                value_name: ENCRYPTED_DOCUMENT_KEY
+                help: Hex-encoded encrypted document key.
+                takes_value: true
+                required: true
+            - requester-secret:
+                long: requester-secret
+                value_name: REQUESTER_SECRET
+                help: Hex-encoded requester secret key.
+                takes_value: true
+                required: true
+            - encrypted-message:
+                long: encrypted-message
+                value_name: ENCRYPTED_MESSAGE
+                help: Hex-encoded encrypted message.
+                takes_value: true
+                required: true
+    - shadow-decrypt-message:
+        about: Decrypt message using document key shadow.
+        args:
+            - common-point:
+                long: common-point
+                value_name: COMMON_POINT
+                help: Hex-encoded common point that has been used during document key generation.
+                takes_value: true
+                required: true
+            - decrypted-secret:
+                long: decrypted-secret
+                value_name: DECRYPTED_SECRET
+                help: Hex-encoded partially decrypted document key.
+                takes_value: true
+                required: true
+            - decrypt-shadows:
+                long: decrypt-shadows
+                value_name: DECRYPT_SHADOW
+                help: Hex-encoded decryption shadows.
+                takes_value: true
+                required: true
+                multiple: true
+                min_values: 1
+            - requester-secret:
+                long: requester-secret
+                value_name: REQUESTER_SECRET
+                help: Hex-encoded requester secret key.
+                takes_value: true
+                required: true
+            - encrypted-message:
+                long: encrypted-message
+                value_name: ENCRYPTED_MESSAGE
+                help: Hex-encoded encrypted message.
+                takes_value: true
+                required: true

--- a/bin/substrate/src/main.rs
+++ b/bin/substrate/src/main.rs
@@ -23,6 +23,7 @@ mod key_server;
 mod key_server_set;
 mod runtime;
 mod service;
+mod subcommands;
 mod substrate_client;
 mod transaction_pool;
 
@@ -41,7 +42,17 @@ use primitives::{
 fn main() {
 	initialize();
 
-	let arguments = match arguments::parse_arguments(None) {
+	let yaml = clap::load_yaml!("cli.yml");
+	let clap_app = clap::App::from_yaml(yaml);
+	let matches = clap_app.get_matches();
+
+	match matches.subcommand() {
+		("sub-submit", Some(sub_submit_matches)) =>
+			return subcommands::submit_transaction::run(sub_submit_matches),
+		_ => (),
+	}
+
+	let arguments = match arguments::parse_arguments(&matches) {
 		Ok(arguments) => arguments,
 		Err(error) => {
 			error!(

--- a/bin/substrate/src/main.rs
+++ b/bin/substrate/src/main.rs
@@ -47,8 +47,18 @@ fn main() {
 	let matches = clap_app.get_matches();
 
 	match matches.subcommand() {
-		("sub-submit", Some(sub_submit_matches)) =>
-			return subcommands::submit_transaction::run(sub_submit_matches),
+		("generate-key-pair", Some(generate_key_pair_matches)) =>
+			return subcommands::generate_key_pair::run(generate_key_pair_matches),
+		("generate-document-key", Some(generate_document_key_matches)) =>
+			return subcommands::generate_document_key::run(generate_document_key_matches),
+		("encrypt-message", Some(encrypt_message_matches)) =>
+			return subcommands::encrypt_message::run(encrypt_message_matches),
+		("decrypt-message", Some(decrypt_message_matches)) =>
+			return subcommands::decrypt_message::run(decrypt_message_matches),
+		("shadow-decrypt-message", Some(shadow_decrypt_message_matches)) =>
+			return subcommands::shadow_decrypt_message::run(shadow_decrypt_message_matches),
+		("submit-transaction", Some(submit_transaction_matches)) =>
+			return subcommands::submit_transaction::run(submit_transaction_matches),
 		_ => (),
 	}
 

--- a/bin/substrate/src/runtime.rs
+++ b/bin/substrate/src/runtime.rs
@@ -57,6 +57,9 @@ pub type Index = substrate_runtime::Index;
 /// Crypto pair that is used to sign transactions.
 pub type Pair = sp_core::sr25519::Pair;
 
+/// Transaction status.
+pub type TransactionStatus = sp_transaction_pool::TransactionStatus<TransactionHash, BlockHash>;
+
 /// Create signer from given SURI and password.
 pub fn create_transaction_signer(
 	signer_uri: &str,

--- a/bin/substrate/src/subcommands/decrypt_message.rs
+++ b/bin/substrate/src/subcommands/decrypt_message.rs
@@ -1,0 +1,67 @@
+// Copyright 2015-2020 Parity Technologies (UK) Ltd.
+// This file is part of Parity Secret Store.
+
+// Parity Secret Store is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity Secret Store is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity Secret Store.  If not, see <http://www.gnu.org/licenses/>.
+
+use clap::ArgMatches;
+use log::{error, info};
+use parity_crypto::publickey::Secret;
+use crate::subcommands::utils::{INIT_VEC_LEN, into_document_key, require_bytes_arg, require_secret_arg};
+
+/// Decrypt message using encrypted document key.
+pub fn run(matches: &ArgMatches) {
+	let parse_arguments = || -> Result<_, String> {
+		let encrypted_document_key = require_bytes_arg(matches, "encrypted-document-key")?;
+		let requester_secret = require_secret_arg(matches, "requester-secret")?;
+		let encrypted_message = require_bytes_arg(matches, "encrypted-message")?;
+		Ok((encrypted_document_key, requester_secret, encrypted_message))
+	};
+
+	let decrypt_message = move |
+		(encrypted_document_key, requester_secret, mut encrypted_message): (Vec<u8>, Secret, Vec<u8>)
+	| -> Result<(), String> {
+		// decrypt document key with requester secret
+		let key = parity_crypto::publickey::ecies::decrypt(
+			&requester_secret,
+			&parity_crypto::DEFAULT_MAC,
+			&encrypted_document_key[..],
+		)
+		.map_err(|err| format!("Error decrypting document key: {}", err))
+		.and_then(into_document_key)?;
+
+		// initialization vector takes INIT_VEC_LEN bytes
+		let encrypted_message_len = encrypted_message.len();
+		if encrypted_message_len < INIT_VEC_LEN {
+			return Err(format!("Invalid encrypted message length: {}", encrypted_message_len));
+		}
+
+		// use symmetric decryption to decrypt document
+		let iv = encrypted_message.split_off(encrypted_message_len - INIT_VEC_LEN);
+		let mut message = vec![0; encrypted_message_len - INIT_VEC_LEN];
+		parity_crypto::aes::decrypt_128_ctr(&key, &iv, &encrypted_message, &mut message)
+			.map_err(|err| format!("Error decrypting message: {}", err))?;
+
+		let sdocument = std::str::from_utf8(&message)
+			.map_err(|err| format!("Error decoding message: {} (supposed to be UTF8-encoded string)", err))?;
+
+		info!(target: "secretstore", "Decrypted message: {:?}", sdocument);
+
+		Ok(())
+	};
+
+	let result = parse_arguments().and_then(decrypt_message);
+	if let Err(error) = result {
+		error!(target: "secretstore", "Failed to decrypt message: {}", error);
+	}
+}

--- a/bin/substrate/src/subcommands/encrypt_message.rs
+++ b/bin/substrate/src/subcommands/encrypt_message.rs
@@ -1,0 +1,66 @@
+// Copyright 2015-2020 Parity Technologies (UK) Ltd.
+// This file is part of Parity Secret Store.
+
+// Parity Secret Store is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity Secret Store is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity Secret Store.  If not, see <http://www.gnu.org/licenses/>.
+
+use clap::ArgMatches;
+use log::{error, info};
+use parity_crypto::publickey::Secret;
+use crate::subcommands::utils::{
+	into_document_key, initialization_vector,
+	require_bytes_arg, require_secret_arg, require_string_arg,
+};
+
+/// Encrypt message using encrypted document key.
+pub fn run(matches: &ArgMatches) {
+	let parse_arguments = || {
+		let encrypted_document_key = require_bytes_arg(matches, "encrypted-document-key")?;
+		let author_secret = require_secret_arg(matches, "author-secret")?;
+		let message = require_string_arg(matches, "message")?.as_bytes().to_vec();
+		Ok((encrypted_document_key, author_secret, message))
+	};
+
+	let encrypt_message = move |
+		(encrypted_document_key, author_secret, message): (Vec<u8>, Secret, Vec<u8>)
+	| -> Result<(), String> {
+		// decrypt document key with author secret
+		let key = parity_crypto::publickey::ecies::decrypt(
+			&author_secret,
+			&parity_crypto::DEFAULT_MAC,
+			&encrypted_document_key[..],
+		)
+		.map_err(|err| format!("Error decrypting document key: {}", err))
+		.and_then(into_document_key)?;
+
+		// use symmetric encryption to encrypt message
+		let iv = initialization_vector();
+		let mut encrypted_message = vec![0; message.len() + iv.len()];
+		{
+			let (mut encryption_buffer, iv_buffer) = encrypted_message.split_at_mut(message.len());
+
+			parity_crypto::aes::encrypt_128_ctr(&key, &iv, &message, &mut encryption_buffer)
+				.map_err(|err| format!("Error encrypting message: {}", err))?;
+			iv_buffer.copy_from_slice(&iv);
+		}
+
+		info!(target: "secretstore", "Encrypted message: 0x{}", hex::encode(encrypted_message));
+
+		Ok(())
+	};
+
+	let result = parse_arguments().and_then(encrypt_message);
+	if let Err(error) = result {
+		error!(target: "secretstore", "Failed to encrypt message: {}", error);
+	}
+}

--- a/bin/substrate/src/subcommands/generate_document_key.rs
+++ b/bin/substrate/src/subcommands/generate_document_key.rs
@@ -1,0 +1,58 @@
+// Copyright 2015-2020 Parity Technologies (UK) Ltd.
+// This file is part of Parity Secret Store.
+
+// Parity Secret Store is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity Secret Store is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity Secret Store.  If not, see <http://www.gnu.org/licenses/>.
+
+use clap::ArgMatches;
+use log::{error, info};
+use parity_crypto::publickey::{Generator, Random};
+use crate::subcommands::utils::require_public_arg;
+
+/// Generate document key.
+pub fn run(matches: &ArgMatches) {
+	let parse_arguments = || {
+		let server_key = require_public_arg(matches, "server-key")?;
+		let author_key = require_public_arg(matches, "author-key")?;
+		Ok((server_key, author_key))
+	};
+
+	let generate_document_key = move |(server_key, author_key)| -> Result<(), String> {
+		// generate plain document key
+		let document_key = Random.generate();
+
+		// encrypt document key using server key
+		let distributed_encrypted_key = key_server::math::encrypt_secret(
+			document_key.public(),
+			&server_key,
+		).map_err(|err| format!("Error generating document key: {}", err))?;
+
+		// ..and now encrypt document key with author public
+		let encrypted_key = parity_crypto::publickey::ecies::encrypt(
+			&author_key,
+			&parity_crypto::DEFAULT_MAC,
+			document_key.public().as_bytes(),
+		).map_err(|err| format!("Error encrypting document key: {}", err))?;
+
+		info!(target: "secretstore", "Common point: {:?}", distributed_encrypted_key.common_point);
+		info!(target: "secretstore", "Encrypted point: {:?}", distributed_encrypted_key.encrypted_point);
+		info!(target: "secretstore", "Encrypted key: 0x{}", hex::encode(encrypted_key));
+
+		Ok(())
+	};
+
+	let result = parse_arguments().and_then(generate_document_key);
+	if let Err(error) = result {
+		error!(target: "secretstore", "Failed to generate document key: {}", error);
+	}
+}

--- a/bin/substrate/src/subcommands/generate_key_pair.rs
+++ b/bin/substrate/src/subcommands/generate_key_pair.rs
@@ -14,10 +14,15 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity Secret Store.  If not, see <http://www.gnu.org/licenses/>.
 
-pub mod decrypt_message;
-pub mod encrypt_message;
-pub mod generate_document_key;
-pub mod generate_key_pair;
-pub mod shadow_decrypt_message;
-pub mod submit_transaction;
-mod utils;
+use clap::ArgMatches;
+use log::info;
+use parity_crypto::publickey::{Generator, Random, public_to_address};
+
+/// Generate Secp256k1 key pair.
+pub fn run(_matches: &ArgMatches) {
+	let key_pair = Random.generate();
+
+	info!(target: "secretstore", "Address: {:?}", public_to_address(key_pair.public()));
+	info!(target: "secretstore", "Public: {:?}", key_pair.public());
+	info!(target: "secretstore", "Secret: {:?}", key_pair.secret());
+}

--- a/bin/substrate/src/subcommands/mod.rs
+++ b/bin/substrate/src/subcommands/mod.rs
@@ -1,0 +1,17 @@
+// Copyright 2015-2020 Parity Technologies (UK) Ltd.
+// This file is part of Parity Secret Store.
+
+// Parity Secret Store is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity Secret Store is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity Secret Store.  If not, see <http://www.gnu.org/licenses/>.
+
+pub mod submit_transaction;

--- a/bin/substrate/src/subcommands/shadow_decrypt_message.rs
+++ b/bin/substrate/src/subcommands/shadow_decrypt_message.rs
@@ -1,0 +1,94 @@
+// Copyright 2015-2020 Parity Technologies (UK) Ltd.
+// This file is part of Parity Secret Store.
+
+// Parity Secret Store is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity Secret Store is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity Secret Store.  If not, see <http://www.gnu.org/licenses/>.
+
+use clap::ArgMatches;
+use log::{error, info};
+use parity_crypto::publickey::{Public, Secret, ec_math_utils};
+use crate::subcommands::utils::{
+	INIT_VEC_LEN, into_document_key,
+	require_bytes_arg, require_multiple_bytes_arg,
+	require_public_arg, require_secret_arg,
+};
+
+/// Decrypt message using document key shadow.
+pub fn run(matches: &ArgMatches) {
+	let parse_arguments = || -> Result<_, String> {
+		let common_point = require_public_arg(matches, "common-point")?;
+		let decrypted_secret = require_public_arg(matches, "decrypted-secret")?;
+		let decrypt_shadows = require_multiple_bytes_arg(matches, "decrypt-shadows")?;
+		let requester_secret = require_secret_arg(matches, "requester-secret")?;
+		let encrypted_message = require_bytes_arg(matches, "encrypted-message")?;
+		Ok((common_point, decrypted_secret, decrypt_shadows, requester_secret, encrypted_message))
+	};
+
+	let decrypt_message = move |
+		(mut common_point, mut decrypted_secret, decrypt_shadows, requester_secret, mut encrypted_message):
+			(Public, Public, Vec<Vec<u8>>, Secret, Vec<u8>)
+	| -> Result<(), String> {
+		// decrypt shadows
+		let decrypted_shadows = decrypt_shadows
+			.into_iter()
+			.map(|decrypt_shadow|
+				parity_crypto::publickey::ecies::decrypt(
+					&requester_secret,
+					&parity_crypto::DEFAULT_MAC,
+					&decrypt_shadow[..],
+				).and_then(|decrypted_shadow| Secret::import_key(&decrypted_shadow))
+				.map_err(|err| format!("Error decrypting shadow: {}", err))
+			)
+			.collect::<Result<Vec<_>, _>>()?;
+
+		// compute sum of shadows
+		let mut total_shadow = decrypted_shadows[0].clone();
+		for decrypted_shadow in decrypted_shadows.iter().skip(1) {
+			total_shadow
+				.add(decrypted_shadow)
+				.map_err(|err| format!("Error computing total shadow: {}", err))?;
+		}
+
+		// use common point and total shadow to restore document key
+		ec_math_utils::public_mul_secret(&mut common_point, &total_shadow)
+			.map_err(|err| format!("Error decrypting document key: {}", err))?;
+		ec_math_utils::public_add(&mut decrypted_secret, &common_point)
+			.map_err(|err| format!("Error decrypting document key: {}", err))?;
+
+		// document key is now decrypted
+		let key = into_document_key(decrypted_secret.as_ref().to_vec())?;
+
+		// initialization vector takes INIT_VEC_LEN bytes
+		let encrypted_message_len = encrypted_message.len();
+		if encrypted_message_len < INIT_VEC_LEN {
+			return Err(format!("Invalid encrypted message length: {}", encrypted_message_len));
+		}
+
+		// use symmetric decryption to decrypt document
+		let iv = encrypted_message.split_off(encrypted_message_len - INIT_VEC_LEN);
+		let mut message = vec![0; encrypted_message_len - INIT_VEC_LEN];
+		parity_crypto::aes::decrypt_128_ctr(&key[..], &iv, &encrypted_message, &mut message)
+			.map_err(|err| format!("Error decrypting message: {}", err))?;
+
+		let sdocument = std::str::from_utf8(&message).map_err(|err| format!("{}", err))?;
+
+		info!(target: "secretstore", "Decrypted message: {:?}", sdocument);
+
+		Ok(())
+	};
+
+	let result = parse_arguments().and_then(decrypt_message);
+	if let Err(error) = result {
+		error!(target: "secretstore", "Failed to decrypt message: {}", error);
+	}
+}

--- a/bin/substrate/src/subcommands/submit_transaction.rs
+++ b/bin/substrate/src/subcommands/submit_transaction.rs
@@ -14,46 +14,47 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity Secret Store.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::str::FromStr;
+use std::{collections::HashMap, str::FromStr};
 use clap::ArgMatches;
 use log::{error, info};
+use parity_crypto::publickey::{public_to_address, Public};
 use primitives::ServerKeyId;
 use crate::substrate_client::Client;
 
 /// All possible SecretStore transactions we support.
 pub enum SecretStoreTransaction {
-/*	// === Meta calls ===
+	// === Meta calls ===
 
 	/// Change owner.
-	ChangeOwner(crate::runtime::AccountId),
+//	ChangeOwner(crate::runtime::AccountId),
 	/// Claim id.
-	ClaimId(Address),
+//	ClaimId(Address),
 	/// Claim key.
 	ClaimKey(ServerKeyId),
 	/// Transfer key ownership.
-	TransferKey(ServerKeyId, Address),
+//	TransferKey(ServerKeyId, Address),
 
 	// === Key Server Set calls ===
 
 	/// Complete key server set initialization.
-	CompleteInitialization,
+//	CompleteInitialization,
 	/// Add key server to the set.
-	AddKeyServer(KeyServerId, String, u16),
+//	AddKeyServer(KeyServerId, String, u16),
 	/// Update key server from the set.
-	UpdateKeyServer(KeyServerId, String, u16),
+//	UpdateKeyServer(KeyServerId, String, u16),
 	/// Remove key server from the set.
-	UpdateKeyServer(KeyServerId),
+//	UpdateKeyServer(KeyServerId),
 
 	// === Key Server calls ===
-*/
+
 	/// Generate server key.
 	GenerateServerKey(ServerKeyId, u8),
 	/// Retrieve server key.
 	RetrieveServerKey(ServerKeyId),
-/*	/// Store document key.
+	/// Store document key.
 	StoreDocumentKey(ServerKeyId, Public, Public),
 	/// Retrieve document key shadow.
-	RetrieveDocumentKeyShadow(ServerKeyId, Public),*/
+	RetrieveDocumentKeyShadow(ServerKeyId, Public),
 }
 
 /// Submit Substrate transaction.
@@ -104,20 +105,54 @@ pub fn run(matches: &ArgMatches) {
 
 /// Parse transaction.
 fn parse_transaction(stransaction: &str) -> Result<SecretStoreTransaction, String> {
+	// to claim key, we only need to provide key id
+	let claim_key_regex = regex::Regex::new(r"ClaimKey\((.*)\)").expect("TODO");
+	if let Some(captures) = claim_key_regex.captures(stransaction) {
+		let key_id = ServerKeyId::from_str(captures.get(1).expect("TODO").as_str().trim_start_matches("0x"))
+			.map_err(|err| format!("{}", err))?;
+		return Ok(SecretStoreTransaction::ClaimKey(key_id));
+	}
+
+	// to generate server key, caller must provide: key id and threshold
 	let generate_server_key_regex = regex::Regex::new(r"GenerateServerKey\((.*),[ /t]*(.*)\)").expect("TODO");
 	if let Some(captures) = generate_server_key_regex.captures(stransaction) {
-		let key_id = ServerKeyId::from_str(captures.get(1).expect("TODO").as_str())
+		let key_id = ServerKeyId::from_str(captures.get(1).expect("TODO").as_str().trim_start_matches("0x"))
 			.map_err(|err| format!("{}", err))?;
-		let threshold = u8::from_str(captures.get(2).expect("TODO").as_str())
+		let threshold = u8::from_str(captures.get(2).expect("TODO").as_str().trim_start_matches("0x"))
 			.map_err(|err| format!("{}", err))?;
 		return Ok(SecretStoreTransaction::GenerateServerKey(key_id, threshold));
 	}
 
+	// to retrieve server key, caller must provide: key id
 	let retrieve_server_key_regex = regex::Regex::new(r"RetrieveServerKey\((.*)\)").expect("TODO");
 	if let Some(captures) = retrieve_server_key_regex.captures(stransaction) {
-		let key_id = ServerKeyId::from_str(captures.get(1).expect("TODO").as_str())
+		let key_id = ServerKeyId::from_str(captures.get(1).expect("TODO").as_str().trim_start_matches("0x"))
 			.map_err(|err| format!("{}", err))?;
 		return Ok(SecretStoreTransaction::RetrieveServerKey(key_id));
+	}
+
+	// to store document key, caller must provide: key id, common point and encrypted point
+	let store_document_key_regex = regex::Regex::new(r"StoreDocumentKey\((.*),[ /t]*(.*),[ /t]*(.*)\)")
+		.expect("TODO");
+	if let Some(captures) = store_document_key_regex.captures(stransaction) {
+		let key_id = ServerKeyId::from_str(captures.get(1).expect("TODO").as_str().trim_start_matches("0x"))
+			.map_err(|err| format!("{}", err))?;
+		let common_point = Public::from_str(captures.get(2).expect("TODO").as_str().trim_start_matches("0x"))
+			.map_err(|err| format!("{}", err))?;
+		let encrypted_point = Public::from_str(captures.get(3).expect("TODO").as_str().trim_start_matches("0x"))
+			.map_err(|err| format!("{}", err))?;
+		return Ok(SecretStoreTransaction::StoreDocumentKey(key_id, common_point, encrypted_point));
+	}
+
+	// to retrieve document key shadow, caller must provide: key id and its (requester) public key
+	let retrieve_document_key_shadow_regex = regex::Regex::new(r"RetrieveDocumentKeyShadow\((.*),[ /t]*(.*)\)")
+		.expect("TODO");
+	if let Some(captures) = retrieve_document_key_shadow_regex.captures(stransaction) {
+		let key_id = ServerKeyId::from_str(captures.get(1).expect("TODO").as_str().trim_start_matches("0x"))
+			.map_err(|err| format!("{}", err))?;
+		let requester_public = Public::from_str(captures.get(2).expect("TODO").as_str().trim_start_matches("0x"))
+			.map_err(|err| format!("{}", err))?;
+		return Ok(SecretStoreTransaction::RetrieveDocumentKeyShadow(key_id, requester_public));
 	}
 
 	Err("unknown call".into())
@@ -131,7 +166,19 @@ async fn process_transaction(
 	is_wait_processed: bool,
 	transaction: SecretStoreTransaction,
 ) -> Result<(), String> {
+	// TODO: even if ClaimKey fails, we still consider it successful
+	// TODO: we consider ClaimKey finalized even if it is not
+	
 	match transaction {
+		SecretStoreTransaction::ClaimKey(id) => process_generic_transaction(
+			&client,
+			is_wait_mined,
+			false,
+			false,
+			crate::runtime::SecretStoreCall::claim_key(id),
+			|_| true,
+			|_| true,
+		).await,
 		SecretStoreTransaction::GenerateServerKey(id, threshold) => process_generic_transaction(
 			&client,
 			is_wait_mined,
@@ -202,6 +249,140 @@ async fn process_transaction(
 				_ => false,
 			},
 		).await,
+		SecretStoreTransaction::StoreDocumentKey(id, common_point, encrypted_point) => process_generic_transaction(
+			&client,
+			is_wait_mined,
+			is_wait_finalized,
+			is_wait_processed,
+			crate::runtime::SecretStoreCall::store_document_key(id, common_point, encrypted_point),
+			move |event| match *event {
+				crate::runtime::Event::secretstore_runtime_module(
+					runtime_module::Event::DocumentKeyStoreRequested(req_id, _, req_cp, req_ep),
+				) if req_id == id && req_cp == common_point && req_ep == encrypted_point => true,
+				_ => false,
+			},
+			move |event| match *event {
+				crate::runtime::Event::secretstore_runtime_module(
+					runtime_module::Event::DocumentKeyStored(req_id),
+				) if req_id == id => {
+					info!(
+						target: "secretstore",
+						"Document key has been stored",
+					);
+					true
+				},
+				crate::runtime::Event::secretstore_runtime_module(
+					runtime_module::Event::DocumentKeyStoreError(req_id),
+				) if req_id == id => {
+					info!(
+						target: "secretstore",
+						"Document key store has failed",
+					);
+					true
+				},
+				_ => false,
+			},
+		).await,
+		SecretStoreTransaction::RetrieveDocumentKeyShadow(id, requester_public) => {
+			let mut common_portion_retrieved = false;
+			let mut threshold = 0xFFu8;
+			let mut personal_portions = HashMap::new();
+			let requester_address = public_to_address(&requester_public);
+
+			process_generic_transaction(
+				&client,
+				is_wait_mined,
+				is_wait_finalized,
+				is_wait_processed,
+				crate::runtime::SecretStoreCall::retrieve_document_key_shadow(id, requester_public),
+				move |event| match *event {
+					crate::runtime::Event::secretstore_runtime_module(
+						runtime_module::Event::DocumentKeyShadowRetrievalRequested(req_id, req_requester),
+					) if req_id == id && requester_address == req_requester => true,
+					_ => false,
+				},
+				move |event| match *event {
+					crate::runtime::Event::secretstore_runtime_module(
+						runtime_module::Event::DocumentKeyCommonRetrieved(
+							req_id,
+							req_requester,
+							req_common_point,
+							req_threshold,
+						),
+					) if req_id == id && requester_address == req_requester => {
+						common_portion_retrieved = true;
+						threshold = req_threshold;
+
+						info!(
+							target: "secretstore",
+							"Common portion of document key has been retrieved: threshold = {}, common_point = {:?}",
+							req_threshold,
+							req_common_point,
+						);
+						false
+					},
+					crate::runtime::Event::secretstore_runtime_module(
+						runtime_module::Event::DocumentKeyPersonalRetrieved(
+							req_id,
+							req_requester,
+							req_decrypted_point,
+							ref req_shadow,
+						),
+					) if
+						common_portion_retrieved &&
+						req_id == id &&
+						requester_address == req_requester
+					=> {
+						let shadows = personal_portions
+							.entry(req_decrypted_point)
+							.or_insert_with(|| {
+								info!(
+									target: "secretstore",
+									"Adding new personal entry candidate: {:?}",
+									req_decrypted_point,
+								);
+
+								Vec::new()
+							});
+
+						shadows.push(req_shadow.clone());
+						if shadows.len() == threshold as usize + 1 {
+							info!(
+								target: "secretstore",
+								"Received last required shadow for personal entry: {:?}",
+								req_decrypted_point,
+							);
+							info!(
+								target: "secretstore",
+								"Finals shadows list: {:?}",
+								shadows,
+							);
+
+							true
+						} else {
+							info!(
+								target: "secretstore",
+								"Received shadow for personal entry: {:?}. {} More required",
+								req_decrypted_point,
+								threshold as usize + 1 - shadows.len(),
+							);
+
+							false
+						}
+					},
+					crate::runtime::Event::secretstore_runtime_module(
+						runtime_module::Event::DocumentKeyShadowRetrievalError(req_id, req_requester),
+					) if req_id == id && requester_address == req_requester => {
+						info!(
+							target: "secretstore",
+							"Document key shadow retrieval has failed",
+						);
+						true
+					},
+					_ => false,
+				},
+			).await
+		},
 	}
 }
 

--- a/bin/substrate/src/subcommands/submit_transaction.rs
+++ b/bin/substrate/src/subcommands/submit_transaction.rs
@@ -1,0 +1,341 @@
+// Copyright 2015-2020 Parity Technologies (UK) Ltd.
+// This file is part of Parity Secret Store.
+
+// Parity Secret Store is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity Secret Store is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity Secret Store.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::str::FromStr;
+use clap::ArgMatches;
+use log::{error, info};
+use primitives::ServerKeyId;
+use crate::substrate_client::Client;
+
+/// All possible SecretStore transactions we support.
+pub enum SecretStoreTransaction {
+/*	// === Meta calls ===
+
+	/// Change owner.
+	ChangeOwner(crate::runtime::AccountId),
+	/// Claim id.
+	ClaimId(Address),
+	/// Claim key.
+	ClaimKey(ServerKeyId),
+	/// Transfer key ownership.
+	TransferKey(ServerKeyId, Address),
+
+	// === Key Server Set calls ===
+
+	/// Complete key server set initialization.
+	CompleteInitialization,
+	/// Add key server to the set.
+	AddKeyServer(KeyServerId, String, u16),
+	/// Update key server from the set.
+	UpdateKeyServer(KeyServerId, String, u16),
+	/// Remove key server from the set.
+	UpdateKeyServer(KeyServerId),
+
+	// === Key Server calls ===
+*/
+	/// Generate server key.
+	GenerateServerKey(ServerKeyId, u8),
+/*	/// Retrieve server key.
+	RetrieveServerKey(ServerKeyId),
+	/// Store document key.
+	StoreDocumentKey(ServerKeyId, Public, Public),
+	/// Retrieve document key shadow.
+	RetrieveDocumentKeyShadow(ServerKeyId, Public),*/
+}
+
+/// Submit Substrate transaction.
+pub fn run(matches: &ArgMatches) {
+	let is_wait_mined = true;
+	let is_wait_finalized = true;
+	let is_wait_processed = true;
+	let transaction = match parse_transaction(
+		matches.value_of("sub-call").expect("TODO")
+	) {
+		Ok(transaction) => transaction,
+		Err(error) => {
+			error!(
+				target: "secretstore",
+				"Failed to parse call: {}",
+				error,
+			);
+			return;
+		},
+	};
+
+	let mut pool = futures::executor::LocalPool::new();
+
+	let client = pool.run_until(
+		Client::new(
+			"ws://127.0.0.1:9944",
+			crate::runtime::create_transaction_signer("//Alice", None).expect("TODO"),
+		)
+	).expect("TODO");
+
+	let result = pool.run_until(
+		process_transaction(
+			client,
+			is_wait_mined,
+			is_wait_finalized,
+			is_wait_processed,
+			transaction,
+		),
+	);
+	if let Err(error) = result {
+		error!(
+			target: "secretstore",
+			"Failed to submit Substrate transaction: {:?}",
+			error,
+		);
+	}
+}
+
+/// Parse transaction.
+fn parse_transaction(stransaction: &str) -> Result<SecretStoreTransaction, String> {
+	let generate_server_key_regex = regex::Regex::new(r"GenerateServerKey\((.*),[ /t]*(.*)\)").expect("TODO");
+	if let Some(captures) = generate_server_key_regex.captures(stransaction) {
+		let key_id = ServerKeyId::from_str(captures.get(1).expect("TODO").as_str())
+			.map_err(|err| format!("{}", err))?;
+		let threshold = u8::from_str(captures.get(2).expect("TODO").as_str())
+			.map_err(|err| format!("{}", err))?;
+		return Ok(SecretStoreTransaction::GenerateServerKey(key_id, threshold));
+	}
+
+	Err("unknown call".into())
+}
+
+/// Submit and wait for transaction.
+async fn process_transaction(
+	client: Client,
+	is_wait_mined: bool,
+	is_wait_finalized: bool,
+	is_wait_processed: bool,
+	transaction: SecretStoreTransaction,
+) -> Result<(), String> {
+	match transaction {
+		SecretStoreTransaction::GenerateServerKey(id, threshold) => {
+			// transaction events stream now (sometimes) missing finality notifications even
+			// in --dev mode. It also may miss finality notifications by design (when too many blocks
+			// are finalized at once)
+			// => we only use it to track Ready+Mined state
+			let mut transaction_stream = client.submit_and_watch_transaction(
+				crate::runtime::Call::SecretStore(
+					crate::runtime::SecretStoreCall::generate_server_key(id, threshold),
+				),
+			).await.map_err(|err| format!("{:?}", err))?;
+			let mut finalized_headers_stream = client.subscribe_finalized_heads()
+				.await
+				.map_err(|err| format!("{:?}", err))?;
+			let mut best_headers_stream = client.subscribe_best_heads()
+				.await
+				.map_err(|err| format!("{:?}", err))?;
+			let find_request = |event: &crate::runtime::Event| match *event {
+				crate::runtime::Event::secretstore_runtime_module(
+					runtime_module::Event::ServerKeyGenerationRequested(gen_id, _, gen_threshold),
+				) if gen_id == id && gen_threshold == threshold => true,
+				_ => false,
+			};
+
+			// wait until transaction is in the Ready queue
+			wait_accepted(&mut transaction_stream).await?;
+			// wait until transaction is mined
+			if is_wait_mined {
+				wait_mined(
+					&client,
+					&mut transaction_stream,
+					find_request,
+				).await?;
+			}
+			// wait until transaction block is finalized
+			if is_wait_finalized {
+				wait_finalized(
+					&client,
+					&mut finalized_headers_stream,
+					find_request,
+				).await?;
+			}
+			// wait until request is processed
+			if is_wait_processed {
+				wait_processed(
+					&client,
+					&mut best_headers_stream,
+					|event| match *event {
+						crate::runtime::Event::secretstore_runtime_module(
+							runtime_module::Event::ServerKeyGenerated(gen_id, gen_key),
+						) if gen_id == id => {
+							info!(
+								target: "secretstore",
+								"Server key has been generated: {:?}",
+								gen_key,
+							);
+							true
+						},
+						_ => false,
+					},
+					|event| match *event {
+						crate::runtime::Event::secretstore_runtime_module(
+							runtime_module::Event::ServerKeyGenerationError(gen_id),
+						) if gen_id == id => {
+							info!(
+								target: "secretstore",
+								"Server key generation has failed",
+							);
+							true
+						},
+						_ => false,
+					},
+				).await?;
+			}
+
+			Ok(())
+		},
+	}
+}
+
+/// Wait until transaction is accepted to the pool.
+async fn wait_accepted(
+	stream: &mut jsonrpsee::client::Subscription<crate::runtime::TransactionStatus>,
+) -> Result<(), String> {
+	loop {
+		let status = stream.next().await;
+		//trace_transaction_status(&status);
+		match status {
+			crate::runtime::TransactionStatus::Ready => {
+				info!(
+					target: "secretstore",
+					"Transaction has been accepted to Ready queue",
+				);
+				return Ok(());
+			},
+			crate::runtime::TransactionStatus::Usurped(_)
+				| crate::runtime::TransactionStatus::Dropped
+				| crate::runtime::TransactionStatus::Invalid
+				=> return Err("Transaction has been dropped".into()),
+			_ => (),
+		}
+	}
+}
+
+/// Wait until transaction is mined.
+async fn wait_mined(
+	client: &Client,
+	stream: &mut jsonrpsee::client::Subscription<crate::runtime::TransactionStatus>,
+	filter_event: impl Fn(&crate::runtime::Event) -> bool,
+) -> Result<(), String> {
+	loop {
+		let status = stream.next().await;
+		//trace_transaction_status(&status);
+		match status {
+			crate::runtime::TransactionStatus::InBlock(block_hash) => {
+				match filter_block_events(client, block_hash, &filter_event, None).await? {
+					Some(FilteredEvent::A) => {
+						info!(
+							target: "secretstore",
+							"Transaction is mined in block: {:?}",
+							block_hash,
+						);
+						return Ok(());
+					},
+					Some(FilteredEvent::B) => unreachable!(
+						"FilteredEvent::B may only happen if we pass two filter functions; qed",
+					),
+					None => return Err("Transaction block is missing required event".into()),
+				}
+			},
+			crate::runtime::TransactionStatus::Usurped(_)
+				| crate::runtime::TransactionStatus::Dropped
+				| crate::runtime::TransactionStatus::Invalid
+				=> return Err("Transaction has been dropped".into()),
+			_ => (),
+		}
+	}
+}
+
+/// Wait until transaction is finalized.
+async fn wait_finalized(
+	client: &Client,
+	finalized_headers_stream: &mut jsonrpsee::client::Subscription<crate::runtime::Header>,
+	filter_event: impl Fn(&crate::runtime::Event) -> bool,
+) -> Result<(), String> {
+	loop {
+		let finalized_header = finalized_headers_stream.next().await;
+		let finalized_header_hash = finalized_header.hash();
+		match filter_block_events(client, finalized_header_hash, &filter_event, None).await? {
+			Some(FilteredEvent::A) => {
+				info!(
+					target: "secretstore",
+					"Transaction block is finalized: {:?}",
+					finalized_header_hash,
+				);
+				return Ok(());
+			},
+			Some(FilteredEvent::B) => unreachable!(
+				"FilteredEvent::B may only happen if we pass two filter functions; qed",
+			),
+			None => (),
+		}
+	}
+}
+
+/// Wait until transaction is processed.
+async fn wait_processed(
+	client: &Client,
+	best_headers_stream: &mut jsonrpsee::client::Subscription<crate::runtime::Header>,
+	filter_successful_event: impl Fn(&crate::runtime::Event) -> bool,
+	filter_failed_event: impl Fn(&crate::runtime::Event) -> bool,
+) -> Result<(), String> {
+	loop {
+		let best_header = best_headers_stream.next().await;
+		let best_header_hash = best_header.hash();
+		match filter_block_events(
+			client,
+			best_header_hash,
+			&filter_successful_event,
+			Some(&filter_failed_event),
+		).await? {
+			Some(_) => return Ok(()),
+			None => (),
+		}
+	}
+}
+
+/// Filter events result.
+enum FilteredEvent { A, B }
+
+/// Filter block events.
+async fn filter_block_events(
+	client: &Client,
+	block_hash: crate::runtime::BlockHash,
+	filter_event1: &dyn Fn(&crate::runtime::Event) -> bool,
+	filter_event2: Option<&dyn Fn(&crate::runtime::Event) -> bool>
+) -> Result<Option<FilteredEvent>, String>{
+	let events = client
+		.header_events(block_hash)
+		.await
+		.map_err(|err| format!("{:?}", err))?;
+	for event in events {
+		if filter_event1(&event.event) {
+			return Ok(Some(FilteredEvent::A));
+		}
+
+		if let Some(filter_event2) = filter_event2 {
+			if filter_event2(&event.event) {
+				return Ok(Some(FilteredEvent::B));
+			}
+		}
+	}
+
+	Ok(None)
+}

--- a/bin/substrate/src/subcommands/utils.rs
+++ b/bin/substrate/src/subcommands/utils.rs
@@ -1,0 +1,96 @@
+// Copyright 2015-2020 Parity Technologies (UK) Ltd.
+// This file is part of Parity Secret Store.
+
+// Parity Secret Store is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity Secret Store is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity Secret Store.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::str::FromStr;
+use clap::ArgMatches;
+use parity_crypto::publickey::{Public, Secret};
+use rand::{RngCore, rngs::OsRng};
+
+/// Proof that argument exists.
+const REQUIRED_ARG_PROOF: &'static str = "ArgMatches are only created when arguments are validated;\
+	this argument is required;\
+	qed";
+
+/// Initialization vector length.
+pub const INIT_VEC_LEN: usize = 16;
+
+/// Convert decrypted document key into actual key for symmetric encryption.
+pub fn into_document_key(key: Vec<u8>) -> Result<Vec<u8>, String> {
+	// key is a previously distributely generated Public
+	if key.len() != 64 {
+		return Err(format!("Invalid document key length: {}", key.len()));
+	}
+
+	// use x coordinate of distributely generated point as encryption key
+	Ok(key[..INIT_VEC_LEN].into())
+}
+
+/// Return random initialization vector.
+pub fn initialization_vector() -> [u8; INIT_VEC_LEN] {
+	let mut result = [0u8; INIT_VEC_LEN];
+	let mut rng = OsRng;
+	rng.fill_bytes(&mut result);
+	result
+}
+
+/// Parse required hex-encoded Vec<u8> arg.
+pub fn require_bytes_arg(matches: &ArgMatches, arg: &str) -> Result<Vec<u8>, String> {
+	hex::decode(
+		matches
+			.value_of(arg)
+			.expect(REQUIRED_ARG_PROOF)
+			.trim_start_matches("0x")
+	).map_err(|err| format!("Failed to parse {} argument: {}", arg, err))
+}
+
+/// Parse required hex-encoded Vec<Vec<u8>> arg.
+pub fn require_multiple_bytes_arg(matches: &ArgMatches, arg: &str) -> Result<Vec<Vec<u8>>, String> {
+	matches
+		.values_of(arg)
+		.expect(REQUIRED_ARG_PROOF)
+		.into_iter()
+		.map(|sbytes| hex::decode(
+			sbytes
+				.trim_start_matches("0x"))
+				.map_err(|err| format!("Failed to parse {} argument: {}", arg, err))
+		)
+		.collect::<Result<Vec<_>, _>>()
+}
+
+/// Parse required hex-encoded Public arg.
+pub fn require_public_arg(matches: &ArgMatches, arg: &str) -> Result<Public, String> {
+	Public::from_str(
+		matches
+			.value_of(arg)
+			.expect(REQUIRED_ARG_PROOF)
+			.trim_start_matches("0x")
+	).map_err(|err| format!("Failed to parse {} argument: {}", arg, err))
+}
+
+/// Parse required hex-encoded Secret arg.
+pub fn require_secret_arg(matches: &ArgMatches, arg: &str) -> Result<Secret, String> {
+	Secret::from_str(
+		matches
+			.value_of(arg)
+			.expect(REQUIRED_ARG_PROOF)
+			.trim_start_matches("0x")
+	).map_err(|err| format!("Failed to parse {} argument: {}", arg, err))
+}
+
+/// Parse required string argument.
+pub fn require_string_arg<'a>(matches: &'a ArgMatches, arg: &str) -> Result<&'a str, String> {
+	Ok(matches.value_of(arg).expect(REQUIRED_ARG_PROOF))
+}

--- a/key-server/src/lib.rs
+++ b/key-server/src/lib.rs
@@ -36,7 +36,7 @@ pub use crate::types::{ServerKeyId, RequestSignature, Public,
 	Error, NodeAddress, ClusterConfiguration};
 pub use crate::key_server::KeyServerImpl;
 pub use crate::traits::KeyServer;
-pub use key_server_cluster::message::Message;
+pub use key_server_cluster::{math, message::Message};
 use primitives::{
 	acl_storage::AclStorage,
 	executor::TokioHandle,


### PR DESCRIPTION
`parity-secretstore-substrate` binary will be able to act as a client of other(s) `parity-secretstore-substrate` instances that are running in key-server mode. I was unable to use Substrate UI to submit SS transactions :/ So this should be a replacement and also a good start/example on how to use the SS-for-Substrate. I'm planning to add some more supported transactions (primarily for modifying key servers set) in next PRs.

For short overview, refer to log in readme - that's the only documentation I'm providing for now ¯\\_(ツ)_/¯