### PR TITLE
Substrate servers set change session fixes

### DIFF
--- a/bin/substrate/README.md
+++ b/bin/substrate/README.md
@@ -93,3 +93,23 @@ RUST_LOG=secretstore=trace,secretstore_net=trace unbuffer ./parity-secretstore-s
 2020-03-27 12:49:08  INFO secretstore Transaction has been accepted to Ready queue
 2020-03-27 12:49:12  INFO secretstore Transaction is mined in block: 0x76d8685136af8096264ac98fa85c0fd2f3f8840a191af3441d2b9ed4c2c50ed8
 ```
+
+## Quick start: adding and removing key servers
+
+```bash
+# Let's add //Dave' key server to the key servers set.
+./parity-secretstore-substrate submit-transaction --wait-processed --transaction="AddKeyServer(0xc48b812bb43401392c037381aca934f4069c0517,127.0.0.1:10003)"
+2020-03-31 16:55:54  INFO secretstore Transaction has been accepted to Ready queue
+2020-03-31 16:56:00  INFO secretstore Transaction is mined in block: 0xffbb7699283266ca82c34ce5a411bc9b00891b1bb115679d7c68799fae91f7fd
+2020-03-31 16:56:13  INFO secretstore Transaction block is finalized: 0xffbb7699283266ca82c34ce5a411bc9b00891b1bb115679d7c68799fae91f7fd
+2020-03-31 16:56:18  INFO secretstore Migration has started
+2020-03-31 16:57:54  INFO secretstore Migration has completed
+
+# Let's remove //Dave' key server from the key servers set.
+./parity-secretstore-substrate submit-transaction --wait-processed --transaction="RemoveKeyServer(0xc48b812bb43401392c037381aca934f4069c0517)"
+2020-03-31 16:58:05  INFO secretstore Transaction has been accepted to Ready queue
+2020-03-31 16:58:06  INFO secretstore Transaction is mined in block: 0x5e38e559af2a5ffbf2ecaab5293498addf421ce59a2fcf1034e62beb70e02258
+2020-03-31 16:58:19  INFO secretstore Transaction block is finalized: 0x5e38e559af2a5ffbf2ecaab5293498addf421ce59a2fcf1034e62beb70e02258
+2020-03-31 16:58:24  INFO secretstore Migration has started
+2020-03-31 16:59:54  INFO secretstore Migration has completed
+```

--- a/key-server/src/network/tcp/mod.rs
+++ b/key-server/src/network/tcp/mod.rs
@@ -545,18 +545,6 @@ fn update_nodes_set(data: Arc<NetConnectionsData>) {
 
 /// Execute maintain procedures of connections trigger.
 fn maintain_connection_trigger(data: Arc<NetConnectionsData>, maintain_action: Option<Maintain>) {
-	if maintain_action == Some(Maintain::SessionAndConnections) || maintain_action == Some(Maintain::Session) {
-		let session_params = data.trigger.lock().maintain_session();
-		if let Some(session_params) = session_params {
-			let session = data.message_processor.start_servers_set_change_session(session_params);
-			match session {
-				Ok(_) => trace!(target: "secretstore_net", "{}: started auto-migrate session",
-					data.self_key_pair.address()),
-				Err(err) => trace!(target: "secretstore_net", "{}: failed to start auto-migrate session with: {}",
-					data.self_key_pair.address(), err),
-			}
-		}
-	}
 	if maintain_action == Some(Maintain::SessionAndConnections) || maintain_action == Some(Maintain::Connections) {
 		let self_node_id = data.self_key_pair.address();
 		let mut trigger = data.trigger.lock();
@@ -588,6 +576,18 @@ fn maintain_connection_trigger(data: Arc<NetConnectionsData>, maintain_action: O
 				if node_to_connect != self_node_id {
 					data.nodes.insert(node_to_connect.clone(), node_addr.clone());
 				}
+			}
+		}
+	}
+	if maintain_action == Some(Maintain::SessionAndConnections) || maintain_action == Some(Maintain::Session) {
+		let session_params = data.trigger.lock().maintain_session();
+		if let Some(session_params) = session_params {
+			let session = data.message_processor.start_servers_set_change_session(session_params);
+			match session {
+				Ok(_) => trace!(target: "secretstore_net", "{}: started auto-migrate session",
+					data.self_key_pair.address()),
+				Err(err) => trace!(target: "secretstore_net", "{}: failed to start auto-migrate session with: {}",
+					data.self_key_pair.address(), err),
 			}
 		}
 	}

--- a/substrate-runtime/module/src/key_server_set.rs
+++ b/substrate-runtime/module/src/key_server_set.rs
@@ -157,28 +157,6 @@ impl<BS, ES, SS> KeyServerSetWithMigration<BS, ES, SS> where
 		Ok(())
 	}
 
-	/// Update key server address.
-	///
-	/// If initialization is already completed, the changes are applied only when
-	/// migration is completed.
-	pub fn update_key_server(
-		&mut self,
-		caller: ES::EntityId,
-		id: KeyServerId,
-		address: KeyServerNetworkAddress,
-	) -> Result<(), &'static str> {
-		self.server_set_storage.ensure_can_modify(caller)?;
-
-		if !self.server_set_storage.is_initialized() {
-			self.server_set_storage.current_mut().update(&id, address.clone())?;
-		}
-		self.server_set_storage.new_mut().update(&id, address)?;
-
-		self.blockchain_storage.deposit_event(Event::KeyServerUpdated(id));
-
-		Ok(())
-	}
-
 	/// Start migration from the current set to the new set.
 	pub fn start_migration(
 		&mut self,

--- a/substrate-runtime/module/src/key_server_set_storage.rs
+++ b/substrate-runtime/module/src/key_server_set_storage.rs
@@ -150,6 +150,8 @@ pub(crate) trait StorageWithMigration {
 	fn is_migration_confirmed(&self, id: &KeyServerId) -> bool;
 	/// Marks current migration completed by given key server.
 	fn confirm_migration(&mut self, id: &KeyServerId);
+	/// Clear migration confirmations from given key servers.
+	fn clear_migration_confirmations(&mut self, key_servers: &BTreeMap<KeyServerId, KeyServer>);
 	/// Set current set change block number.
 	fn set_current_change_block(&mut self, block: Self::BlockNumber);
 
@@ -308,6 +310,12 @@ impl<T: Trait> StorageWithMigration for RuntimeStorageWithMigration<T> {
 
 	fn confirm_migration(&mut self, id: &KeyServerId) {
 		MigrationConfirmations::insert(id, ())
+	}
+
+	fn clear_migration_confirmations(&mut self, key_servers: &BTreeMap<KeyServerId, KeyServer>) {
+		for id in key_servers.keys() {
+			MigrationConfirmations::remove(id);
+		}
 	}
 
 	fn set_current_change_block(&mut self, block: Self::BlockNumber) {

--- a/substrate-runtime/module/src/lib.rs
+++ b/substrate-runtime/module/src/lib.rs
@@ -110,13 +110,6 @@ decl_module! {
 			key_server_set::<T>().add_key_server(origin, id, network_address)?;
 		}
 
-		/// Update key server in the set.
-		///
-		/// Can only be called by owner.
-		pub fn update_key_server(origin, id: KeyServerId, network_address: KeyServerNetworkAddress) {
-			key_server_set::<T>().update_key_server(origin, id, network_address)?;
-		}
-
 		/// Remove key server from the set.
 		///
 		/// Can only be called by owner.


### PR DESCRIPTION
1) removed `update_key_server()` call - it is too tricky to handle it easily (without migration);
2) we do not restart same-id migration session too often to leave time for transactions to be mined and finalized
3) (the worst bug) migration confirmations are now removed when migration completes